### PR TITLE
sydneyli/starttls-scanner => EFForg/starttls-scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.8
 
-ADD . /go/src/github.com/sydneyli/starttls-scanner
+ADD . /go/src/github.com/EFForg/starttls-scanner
 
-RUN go get github.com/sydneyli/starttls-scanner
-RUN go install github.com/sydneyli/starttls-scanner
+RUN go get github.com/EFForg/starttls-scanner
+RUN go install github.com/EFForg/starttls-scanner
 
 ENTRYPOINT /go/bin/starttls-scanner
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Requires `go` and `postgres` installations. You can specify the following enviro
  - `DB_USERNAME` / `DB_PASSWORD` - username and password for database access.
 
 ```
-go get github.com/sydneyli/starttls-scanner
-cd $GOPATH/github.com/sydneyli/starttls-scanner
+go get github.com/EFForg/starttls-scanner
+cd $GOPATH/github.com/EFForg/starttls-scanner
 ```
 
 You'll also want to ensure `postgres` is running, then run `db/scripts/init_db.sql` in the appropriate postgres DB in order to initialize your database.

--- a/api.go
+++ b/api.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/EFForg/starttls-scanner/db"
 	"github.com/sydneyli/starttls-check/checker"
-	"github.com/sydneyli/starttls-scanner/db"
 )
 
 ////////////////////////////////

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sydneyli/starttls-scanner/db"
+	"github.com/EFForg/starttls-scanner/db"
 )
 
 // Global database object for tests.

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/sydneyli/starttls-scanner/db"
+	"github.com/EFForg/starttls-scanner/db"
 )
 
 func validPort(port string) (string, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sydneyli/starttls-scanner/db"
+	"github.com/EFForg/starttls-scanner/db"
 )
 
 // Workflow tests against REST API.


### PR DESCRIPTION
Migrating the repo over to EFForg means all the links had to change too.