### PR TITLE
Logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/EFForg/starttls-scanner/db"
+	"github.com/gorilla/handlers"
 )
 
 func validPort(port string) (string, error) {
@@ -26,7 +28,8 @@ func ServePublicEndpoints(api *API, cfg *db.Config) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Fatal(http.ListenAndServe(portString, mux))
+	requestLogger := handlers.LoggingHandler(os.Stdout, mux)
+	log.Fatal(http.ListenAndServe(portString, requestLogger))
 }
 
 func main() {


### PR DESCRIPTION
I read a bit about the DefaultServeMux (which is used when handlers are registered with `http.HandleFunc`) and it seems preferable to declare our own mux so we have more control over which handlers are registered.

Gorilla Toolkit provides some utility handlers that look good to me, so I went with that for logging. More on that choice in #11.

Should this have a test? I wasn't sure.