### PR TITLE
bugfix: Re-inserting tokens for a domain updates existing token

### DIFF
--- a/api.go
+++ b/api.go
@@ -89,7 +89,6 @@ func (api API) Queue(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
-		// 0. TODO: ensure domain doesn't already exist
 		// 1. Insert domain into DB
 		err := api.Database.PutDomain(db.DomainData{
 			Name:  domain,

--- a/db/memdb.go
+++ b/db/memdb.go
@@ -49,7 +49,20 @@ func (db *MemDatabase) UseToken(token_str string) (string, error) {
 	return token.Domain, nil
 }
 
+func (db *MemDatabase) getTokenForDomain(domain string) (string, error) {
+	for token, tokenData := range db.tokens {
+		if tokenData.Domain == domain {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("Couldn't find an entry for this domain!")
+}
+
 func (db *MemDatabase) PutToken(domain string) (TokenData, error) {
+	existingToken, err := db.getTokenForDomain(domain)
+	if err == nil {
+		delete(db.tokens, existingToken)
+	}
 	token := TokenData{
 		Domain: domain,
 		Token:  randToken(),

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -53,7 +53,8 @@ func (db *SqlDatabase) PutToken(domain string) (TokenData, error) {
 		Expires: time.Now().Add(time.Duration(time.Hour * 72)),
 		Used:    false,
 	}
-	_, err := db.Conn.Exec("INSERT INTO tokens(domain, token, expires) VALUES($1, $2, $3)",
+	_, err := db.Conn.Exec("INSERT INTO tokens(domain, token, expires) VALUES($1, $2, $3) "+
+		"ON CONFLICT (domain) DO UPDATE SET token=$2, expires=$3",
 		domain, tokenData.Token, tokenData.Expires.UTC().Format(SqlTimeFormat))
 	if err != nil {
 		return TokenData{}, err

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -39,12 +39,6 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-///////////////////////////
-// ***** API tests ***** //
-///////////////////////////
-
-// TODO (sydli)
-
 ////////////////////////////////
 // ***** Database tests ***** //
 ////////////////////////////////
@@ -181,5 +175,21 @@ func TestPutUseToken(t *testing.T) {
 	}
 	if domain != data.Domain {
 		t.Errorf("UseToken used token for %s instead of %s\n", domain, data.Domain)
+	}
+}
+
+func TestPutTokenTwice(t *testing.T) {
+	database.ClearTables()
+	data, err := database.PutToken("testing.com")
+	if err != nil {
+		t.Errorf("PutToken failed: %v\n", err)
+	}
+	_, err = database.PutToken("testing.com")
+	if err != nil {
+		t.Errorf("PutToken failed: %v\n", err)
+	}
+	domain, err := database.UseToken(data.Token)
+	if domain == data.Domain {
+		t.Errorf("UseToken should not have succeeded with old token!\n", domain, data.Domain)
 	}
 }


### PR DESCRIPTION
Fixes #7.

Updates `mem_db.go` and `sql_db.go` to "upsert" tokens correctly, and add tests to `db/sqldb_test.go` and `main_test.go` to test for this.