### PR TITLE
Allow cross-origin requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Port to listen for requests on
 PORT=8080
+# Permitted domains for cross-origin requests, e.g. http://localhost:1313
+ALLOWED_ORIGINS=
 
 # The name of the database, e.g. `starttls` or `starttls_dev`
 # (this should be created in advance)

--- a/main.go
+++ b/main.go
@@ -23,8 +23,10 @@ func registerHandlers(api *API, mux *http.ServeMux) http.Handler {
 	mux.HandleFunc("/api/queue", api.Queue)
 	mux.HandleFunc("/api/validate", api.Validate)
 
+	originsOk := handlers.AllowedOrigins([]string{os.Getenv("ALLOWED_ORIGINS")})
+
 	return handlers.RecoveryHandler()(
-		handlers.LoggingHandler(os.Stdout, mux),
+		handlers.CORS(originsOk)(handlers.LoggingHandler(os.Stdout, mux)),
 	)
 }
 


### PR DESCRIPTION
For local development with Hugo, for example.