### PR TITLE
Change starttls-check call to match new API

### DIFF
--- a/api.go
+++ b/api.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/EFForg/starttls-check/checker"
 	"github.com/EFForg/starttls-scanner/db"
-	"github.com/sydneyli/starttls-check/checker"
 )
 
 ////////////////////////////////
@@ -38,9 +38,9 @@ type API struct {
 }
 
 func defaultCheck(domain string) (string, error) {
-	// false and true specify which of the checks we'd like to perform--
-	// Only STARTTLS but not MTASTS.
-	return checker.PerformChecksJSON(domain, false, true)
+	result := checker.CheckDomain(domain, nil)
+	byteArray, err := json.Marshal(result)
+	return string(byteArray), err
 }
 
 // Scan allows GET or POST /api/scan?domain=abc.com

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ import (
 var api *API
 
 func mockCheckPerform(domain string) (string, error) {
-	return fmt.Sprintf("{\n\"Domain\": \"%s\"\n}", domain), nil
+	return fmt.Sprintf("{\n\"domain\": \"%s\"\n}", domain), nil
 }
 
 // Load env. vars, initialize DB hook, and tests API
@@ -237,7 +237,7 @@ func TestBasicScan(t *testing.T) {
 	if err != nil {
 		t.Errorf("Returned invalid JSON object:%v\n", string(scanBody))
 	}
-	if domain, ok := jsonObj["Domain"]; !ok {
+	if domain, ok := jsonObj["domain"]; !ok {
 		t.Errorf("Scan JSON should contain Domain field")
 	} else {
 		if domain != "eff.org" {


### PR DESCRIPTION
Fixes #26 .

The `nil` argument that we pass to `CheckDomain` is since we don't yet want to specify an MX policy for that domain-- i.e., we don't necessarily know what set of names are valid for the certificates on those boxes.

So for this check, the default `nil` implies that the certificate checking function should only validate for either 1) the explicit hostname or 2) the explicit mail domain. For instance, if we were checking mailserver `mx5.mailbox.example.org` for `example.org`, the certificate should validate for either of those FQDNs.

This is the default checker's behavior, since there's not really a consistent standard for cert validation on MTAs (having a cert valid for the mail domain `@example.org` on your mailserver is more secure and guaranteed to protect against DNS MitM, but people do use hosting providers, so not everyone can do this).

For instance, if we wanted to validate a domain's entry on the policy list, the policy of `example.org` might include `mxs: ["example.org"]` or `mxs: [".mailbox.example.org", "mx.example.org"]`. In both cases, we'd pass this array as the second parameter of `CheckDomain`. More details about the rules around validating this field is [here](https://github.com/EFForg/starttls-everywhere/blob/master/RULES.md#mxs).