### PR TITLE
Handle SES bounce and complaint notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ SMTP_ENDPOINT=
 SMTP_PORT=
 SMTP_FROM_ADDRESS=
 
+# Authorize key for AWS SNS email notifications (eg. bounces)
+AMAZON_AUTHORIZE_KEY=
+
 # Error reporting
 SENTRY_URL=
 

--- a/.env.test.example
+++ b/.env.test.example
@@ -3,3 +3,5 @@ TEST_DB_NAME=starttls_test
 DB_USERNAME=postgres
 DB_PASSWORD=password
 DB_HOST=postgres_test
+
+AMAZON_AUTHORIZE_KEY=test

--- a/db/db.go
+++ b/db/db.go
@@ -50,7 +50,7 @@ type TokenData struct {
 	Used    bool      `json:"used"`    // Whether this token was used.
 }
 
-//BounceData stores the emails from which we've recieved bounce or complaint notifications.
+// EmailBlacklistData stores the emails from which we've recieved bounce or complaint notifications.
 type EmailBlacklistData struct {
 	Email     string    // Email to blacklist.
 	Timestamp time.Time // When the bounce or complaint occured.

--- a/db/db.go
+++ b/db/db.go
@@ -50,6 +50,13 @@ type TokenData struct {
 	Used    bool      `json:"used"`    // Whether this token was used.
 }
 
+//BounceData stores the emails from which we've recieved bounce or complaint notifications.
+type EmailBlacklistData struct {
+	Email     string    // Email to blacklist.
+	Timestamp time.Time // When the bounce or complaint occured.
+	Reason    string    // eg. "bounce" or "complaint"
+}
+
 // Database interface: These are the things that the Database should be able to do.
 // Slightly more limited than CRUD for all the schemas.
 type Database interface {
@@ -71,6 +78,10 @@ type Database interface {
 	PutToken(string) (TokenData, error)
 	// Uses a token in the db
 	UseToken(string) (string, error)
+	// Adds a bounce or complaint notification to the email blacklist.
+	PutBlacklistedEmail(email string, reason string, timestamp string) error
+	// Returns true if we've blacklisted an email.
+	IsBlacklistedEmail(string) (bool, error)
 	ClearTables() error
 }
 

--- a/db/scripts/init_tables.sql
+++ b/db/scripts/init_tables.sql
@@ -23,3 +23,12 @@ CREATE TABLE IF NOT EXISTS domains
     data        TEXT NOT NULL,
     status      VARCHAR(255) NOT NULL
 );
+
+
+CREATE TABLE IF NOT EXISTS blacklisted_emails
+(
+    id          SERIAL PRIMARY KEY,
+    email       TEXT NOT NULL,
+    reason      TEXT NOT NULL,
+    timestamp   TIMESTAMP
+);

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -194,14 +194,14 @@ func (db SQLDatabase) GetDomains(state DomainState) ([]DomainData, error) {
 
 // EMAIL BLACKLIST DB FUNCTIONS
 
-// PutBlacklistedEmail dds a bounce or complaint notification to the email blacklist.
+// PutBlacklistedEmail adds a bounce or complaint notification to the email blacklist.
 func (db SQLDatabase) PutBlacklistedEmail(email string, reason string, timestamp string) error {
 	_, err := db.conn.Exec("INSERT INTO blacklisted_emails(email, reason, timestamp) VALUES($1, $2, $3)",
 		email, reason, timestamp)
 	return err
 }
 
-// IsBlacklistedEmail eturns true iff we've blacklisted the passed email address for sending.
+// IsBlacklistedEmail returns true iff we've blacklisted the passed email address for sending.
 func (db SQLDatabase) IsBlacklistedEmail(email string) (bool, error) {
 	var count int
 	row := db.conn.QueryRow("SELECT COUNT(*) FROM blacklisted_emails")

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -204,7 +204,7 @@ func (db SQLDatabase) PutBlacklistedEmail(email string, reason string, timestamp
 // IsBlacklistedEmail returns true iff we've blacklisted the passed email address for sending.
 func (db SQLDatabase) IsBlacklistedEmail(email string) (bool, error) {
 	var count int
-	row := db.conn.QueryRow("SELECT COUNT(*) FROM blacklisted_emails")
+	row := db.conn.QueryRow("SELECT COUNT(*) FROM blacklisted_emails WHERE email=$1", email)
 	err := row.Scan(&count)
 	if err != nil {
 		return false, err

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -191,14 +191,14 @@ func (db SQLDatabase) GetDomains(state DomainState) ([]DomainData, error) {
 
 // EMAIL BLACKLIST DB FUNCTIONS
 
-// Adds a bounce or complaint notification to the email blacklist.
+// PutBlacklistedEmail dds a bounce or complaint notification to the email blacklist.
 func (db SQLDatabase) PutBlacklistedEmail(email string, reason string, timestamp string) error {
 	_, err := db.conn.Exec("INSERT INTO blacklisted_emails(email, reason, timestamp) VALUES($1, $2, $3)",
 		email, reason, timestamp)
 	return err
 }
 
-// Returns true iff we've blacklisted the passed email address for sending.
+// IsBlacklistedEmail eturns true iff we've blacklisted the passed email address for sending.
 func (db SQLDatabase) IsBlacklistedEmail(email string) (bool, error) {
 	var count int
 	row := db.conn.QueryRow("SELECT COUNT(*) FROM blacklisted_emails")

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -238,3 +238,31 @@ func TestHostnamesForDomain(t *testing.T) {
 	}
 
 }
+
+func TestPutAndIsBlacklistedEmail(t *testing.T) {
+	defer database.ClearTables()
+
+	// Add an e-mail address to the blacklist.
+	err := database.PutBlacklistedEmail("fail@example.com", "bounce", "2017-07-21T18:47:13.498Z")
+	if err != nil {
+		t.Errorf("PutBlacklistedEmail failed: %v\n", err)
+	}
+
+	// Check that the email address was blacklisted.
+	blacklisted, err := database.IsBlacklistedEmail("fail@example.com")
+	if err != nil {
+		t.Errorf("IsBlacklistedEmail failed: %v\n", err)
+	}
+	if !blacklisted {
+		t.Errorf("fail@example.com should be blacklisted, but wasn't")
+	}
+
+	// Check that an un-added email address is not blacklisted.
+	blacklisted, err = database.IsBlacklistedEmail("good@example.com")
+	if err != nil {
+		t.Errorf("IsBlacklistedEmail failed: %v\n", err)
+	}
+	if blacklisted {
+		t.Errorf("good@example.com should not be blacklisted, but was")
+	}
+}

--- a/email.go
+++ b/email.go
@@ -201,8 +201,11 @@ func handleSESNotification(database db.Database) func(http.ResponseWriter, *http
 		}
 
 		for _, recipient := range data.recipients {
-			tags := map[string]string{"email": recipient.EmailAddress}
-			raven.CaptureMessage("Received SES complaint notification", tags)
+			tags := map[string]string{
+				"email":             recipient.EmailAddress,
+				"notification_type": data.reason,
+			}
+			raven.CaptureMessage("Received SES notification", tags)
 
 			err = database.PutBlacklistedEmail(recipient.EmailAddress, data.reason, data.timestamp)
 			if err != nil {

--- a/email.go
+++ b/email.go
@@ -127,18 +127,18 @@ type blacklistRequest struct {
 	reason     string
 	timestamp  string
 	recipients Recipients
-	raw        rawSNSMessages
+	raw        rawSNSMessage
 }
 
-type rawSNSMessages string
+type rawSNSMessage string
 
 // Class satisfies raven's Interface interface so we can send this as extra context.
 // https://github.com/getsentry/raven-go/issues/125
-func (r rawSNSMessages) Class() string {
+func (r rawSNSMessage) Class() string {
 	return "extra"
 }
 
-func (r rawSNSMessages) MarshalJSON() ([]byte, error) {
+func (r rawSNSMessage) MarshalJSON() ([]byte, error) {
 	return []byte(r), nil
 }
 

--- a/email.go
+++ b/email.go
@@ -119,62 +119,59 @@ func (c emailConfig) sendEmail(subject string, body string, address string) erro
 		c.sender, []string{address}, []byte(message))
 }
 
+type Recipients []struct {
+	EmailAddress string `json:"emailAddress"`
+}
+
 type blacklistRequest struct {
 	reason     string
 	timestamp  string
-	recipients []struct {
-		EmailAddress string `json:"emailAddress"`
-	}
+	recipients Recipients
 }
 
 // UnmarshallJSON wrangles the JSON posted by AWS SNS into something easier to access
 // and generalized across notification types.
 func (r *blacklistRequest) UnmarshalJSON(b []byte) error {
+	// We need to start by unmarshalling Message into a string because the field contains stringified JSON.
+	// See email_test.go for examples.
 	var wrapper struct {
-		Message string
+		Message   string
+		Timestamp string
 	}
 	if err := json.Unmarshal(b, &wrapper); err != nil {
 		return fmt.Errorf("failed to load notification wrapper: %v", err)
 	}
 
-	// We need to unmarshall a second time because Message is posted as a JSON-encoded string.
-	// See email_test.go for examples.
-	var msg struct {
-		NotificationType string `json:"notificationType"`
-		Complaint        struct {
-			ComplainedRecipients []struct {
-				EmailAddress string `json:"emailAddress"`
-			} `json:"complainedRecipients"`
-			Timestamp string `json:"timestamp"`
-		} `json:"complaint"`
-		Bounce struct {
-			BouncedRecipients []struct {
-				EmailAddress string `json:"emailAddress"`
-			} `json:"bouncedRecipients"`
-			Timestamp string `json:"timestamp"`
-		} `json:"bounce"`
+	type Complaint struct {
+		*Recipients `json:"complainedRecipients"`
 	}
+
+	type Bounce struct {
+		*Recipients `json:"bouncedRecipients"`
+	}
+
+	// We'll unmarshall the list of bounced or complained emails into
+	// &recipients.  Only one of Complaint or Bounce will contain data, so we can
+	// reuse &recipients to capture whichever field holds the list.
+	var recipients Recipients
+	msg := struct {
+		NotificationType string `json:"notificationType"`
+		Complaint        `json:"complaint"`
+		Bounce           `json:"bounce"`
+	}{
+		Complaint: Complaint{Recipients: &recipients},
+		Bounce:    Bounce{Recipients: &recipients},
+	}
+
 	if err := json.Unmarshal([]byte(wrapper.Message), &msg); err != nil {
 		return fmt.Errorf("failed to load notification message: %v", err)
 	}
 
-	switch msg.NotificationType {
-	case "Complaint":
-		*r = blacklistRequest{
-			reason:     msg.NotificationType,
-			timestamp:  msg.Complaint.Timestamp,
-			recipients: msg.Complaint.ComplainedRecipients,
-		}
-	case "Bounce":
-		*r = blacklistRequest{
-			reason:     msg.NotificationType,
-			timestamp:  msg.Bounce.Timestamp,
-			recipients: msg.Bounce.BouncedRecipients,
-		}
-	default:
-		return fmt.Errorf("SES notification did not match expected format")
+	*r = blacklistRequest{
+		timestamp:  wrapper.Timestamp,
+		reason:     msg.NotificationType,
+		recipients: recipients,
 	}
-
 	return nil
 }
 

--- a/email.go
+++ b/email.go
@@ -119,6 +119,7 @@ func (c emailConfig) sendEmail(subject string, body string, address string) erro
 		c.sender, []string{address}, []byte(message))
 }
 
+// Recipients lists the email addresses that have triggered a bounce or complaint.
 type Recipients []struct {
 	EmailAddress string `json:"emailAddress"`
 }

--- a/email.go
+++ b/email.go
@@ -215,7 +215,7 @@ func handleSESNotification(database db.Database) func(http.ResponseWriter, *http
 		}
 
 		tags := map[string]string{"notification_type": data.reason}
-		raven.CaptureMessageAndWait("Received SES notification", tags, data.raw)
+		raven.CaptureMessage("Received SES notification", tags, data.raw)
 
 		for _, recipient := range data.recipients {
 			err = database.PutBlacklistedEmail(recipient.EmailAddress, data.reason, data.timestamp)

--- a/email.go
+++ b/email.go
@@ -131,15 +131,14 @@ type blacklistRequest struct {
 // and generalized across notification types.
 func (r *blacklistRequest) UnmarshalJSON(b []byte) error {
 	var wrapper struct {
-		Type      string
-		MessageID string
-		Message   string
-		Timestamp string
+		Message string
 	}
 	if err := json.Unmarshal(b, &wrapper); err != nil {
 		return fmt.Errorf("failed to load notification wrapper: %v", err)
 	}
 
+	// We need to unmarshall a second time because Message is posted as a JSON-encoded string.
+	// See email_test.go for examples.
 	var msg struct {
 		NotificationType string `json:"notificationType"`
 		Complaint        struct {

--- a/email.go
+++ b/email.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/smtp"
+	"os"
 	"strings"
 
 	"github.com/EFForg/starttls-scanner/db"
@@ -148,7 +149,11 @@ func parseComplaintJSON(messageJSON []byte) (snsMessage, error) {
 }
 
 func handleSESNotification(w http.ResponseWriter, r *http.Request) {
-	// raise ActiveRecord::RecordNotFound unless params["amazon_authorize_key"] == Rails.application.secrets.amazon_authorize_key
+	keyParam := r.URL.Query()["amazon_authorize_key"]
+	if len(keyParam) == 0 || keyParam[0] != os.Getenv("AMAZON_AUTHORIZE_KEY") {
+		return
+	}
+
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		// Log to sentry and return

--- a/email.go
+++ b/email.go
@@ -4,7 +4,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"net/smtp"
 	"strings"
 
@@ -124,9 +126,9 @@ type snsMessage struct {
 	} `json:"complaint"`
 }
 
-func parseComplaintJSON(messageJSON string) (snsMessage, error) {
+func parseComplaintJSON(messageJSON []byte) (snsMessage, error) {
 	var wrapper snsWrapper
-	if err := json.Unmarshal([]byte(messageJSON), &wrapper); err != nil {
+	if err := json.Unmarshal(messageJSON, &wrapper); err != nil {
 		return snsMessage{}, fmt.Errorf("failed to load complaint wrapper: %v", err)
 	}
 
@@ -136,4 +138,17 @@ func parseComplaintJSON(messageJSON string) (snsMessage, error) {
 		return snsMessage{}, fmt.Errorf("failed to load complaint: %v", err)
 	}
 	return complaint, nil
+}
+
+func handleSESNotification(w http.ResponseWriter, r *http.Request) {
+	// raise ActiveRecord::RecordNotFound unless params["amazon_authorize_key"] == Rails.application.secrets.amazon_authorize_key
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		// Log to sentry and return
+	}
+	complaint, err := parseComplaintJSON(body)
+	if err != nil {
+		// Log to sentry and return
+	}
+	log.Println(complaint)
 }

--- a/email.go
+++ b/email.go
@@ -125,6 +125,8 @@ type blacklistRequest struct {
 	}
 }
 
+// UnmarshallJSON wrangles the JSON posted by AWS SNS into something easier to access
+// and generalized across notification types.
 func (n *blacklistRequest) UnmarshalJSON(b []byte) error {
 	var wrapper struct {
 		Type      string
@@ -175,6 +177,9 @@ func (n *blacklistRequest) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// handleSESNotification handles AWS SES bounces and complaints submitted to a webhook
+// via AWS SNS (Simple Notification Service).
+// The SNS webwook is configured to include a secret API key stored in the environment.
 func handleSESNotification(w http.ResponseWriter, r *http.Request) {
 	keyParam := r.URL.Query()["amazon_authorize_key"]
 	if len(keyParam) == 0 || keyParam[0] != os.Getenv("AMAZON_AUTHORIZE_KEY") {

--- a/email.go
+++ b/email.go
@@ -180,7 +180,7 @@ func (r *blacklistRequest) UnmarshalJSON(b []byte) error {
 
 // handleSESNotification handles AWS SES bounces and complaints submitted to a webhook
 // via AWS SNS (Simple Notification Service).
-// The SNS webwook is configured to include a secret API key stored in the environment.
+// The SNS webhook is configured to include a secret API key stored in the environment.
 func handleSESNotification(database db.Database) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		keyParam := r.URL.Query()["amazon_authorize_key"]

--- a/email_test.go
+++ b/email_test.go
@@ -70,6 +70,18 @@ func TestParseSESNotification(t *testing.T) {
 	}
 }
 
+func TestSendEmailToBlacklistedAddressFails(t *testing.T) {
+	err := api.Database.PutBlacklistedEmail("fail@example.com", "bounce", "2017-07-21T18:47:13.498Z")
+	if err != nil {
+		t.Errorf("PutBlacklistedEmail failed: %v\n", err)
+	}
+	c := &emailConfig{database: api.Database}
+	err = c.sendEmail("Subject", "Body", "fail@example.com")
+	if !strings.Contains(err.Error(), "blacklisted") {
+		t.Error("attempting to send mail to blacklisted address should fail")
+	}
+}
+
 func TestHandleSESNotification(t *testing.T) {
 	defer teardown()
 

--- a/email_test.go
+++ b/email_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -34,7 +36,7 @@ func TestRequireEnvConfig(t *testing.T) {
 }
 
 func TestParseComplaintJSON(t *testing.T) {
-	message, err := parseComplaintJSON(complaintJSON)
+	message, err := parseComplaintJSON([]byte(complaintJSON))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,6 +48,16 @@ func TestParseComplaintJSON(t *testing.T) {
 			t.Error("Failed to parse email address from recipient")
 		}
 	}
+}
+
+func TestSESComplaint(t *testing.T) {
+	defer teardown()
+
+	resp, err := http.Post(server.URL+"/sns", "application/json", strings.NewReader(complaintJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Println(resp)
 }
 
 const complaintJSON = `{

--- a/email_test.go
+++ b/email_test.go
@@ -32,3 +32,30 @@ func TestRequireEnvConfig(t *testing.T) {
 		t.Errorf("should have received multiple error from unset env vars")
 	}
 }
+
+func TestParseComplaintJSON(t *testing.T) {
+	message, err := parseComplaintJSON(complaintJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(message.Complaint.ComplainedRecipients) == 0 {
+		t.Error("Failed to parse recipients from complaint")
+	}
+	for _, recipient := range message.Complaint.ComplainedRecipients {
+		if len(recipient.EmailAddress) == 0 {
+			t.Error("Failed to parse email address from recipient")
+		}
+	}
+}
+
+const complaintJSON = `{
+"Type" : "Notification",
+"MessageId" : "4cf6e02c-a704-5b80-81e7-b1c0e975734c",
+"TopicArn" : "arn:aws:sns:us-west-2:486751131363:ses-complaint",
+"Message" : "{\"notificationType\":\"Complaint\",\"complaint\":{\"complainedRecipients\":[{\"emailAddress\":\"complaint@simulator.amazonses.com\"}],\"timestamp\":\"2017-07-21T18:47:12.000Z\",\"feedbackId\":\"0101015d6679a0d7-02992932-6e45-11e7-8b8d-230f97f3b45c-000000\",\"userAgent\":\"Amazon SES Mailbox Simulator\",\"complaintFeedbackType\":\"abuse\"},\"mail\":{\"timestamp\":\"2017-07-21T18:47:10.000Z\",\"source\":\"actioncenter@eff.org\",\"sourceArn\":\"arn:aws:ses:us-west-2:486751131363:identity/eff.org\",\"sourceIp\":\"52.52.0.175\",\"sendingAccountId\":\"486751131363\",\"messageId\":\"0101015d66799783-25cb1bc6-44c7-408b-85b0-5303265489f6-000000\",\"destination\":[\"complaint@simulator.amazonses.com\"]}}",
+"Timestamp" : "2017-07-21T18:47:13.498Z",
+"SignatureVersion" : "1",
+"Signature" : "L/DQz0vk1Lb95bGAhZJNRtMah4rholuL1NZvtRym/VA6ifWet/ZMn3NsJolHhbaQZIIlq+EV2gHRzDdtFB9eLm5Ia156VOxhv6dsbRMKlU5morLuF6GOSb1lRHTkJmv/vJJFoIuEKAVkhKhGofavbzCojBLhqubnJ8D4XGreM7jnprDbupRt+VsVokOa3zaWGsmqEkH9RnAejccexyZN7g3LEdq4vTz3qO8OCIXCDEe6B8/L1Y1DCZSbH/RD6AaDG6zyJt1EGZEApJODCZgazFlifWJWfeBb31UTfSQKZ+9b3FB8vJQ9FpaUs9m/XQxLn265+9ETLCzgs6TYq1k9Hg==",
+"SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem",
+"UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:486751131363:ses-complaint:de9c5dc1-d0b7-411b-9410-bd3e4b760f1b"
+}`

--- a/email_test.go
+++ b/email_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,11 +40,11 @@ func TestParseComplaintJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(message.Complaint.ComplainedRecipients) == 0 {
-		t.Error("Failed to parse recipients from complaint")
+		t.Error("failed to parse recipients from complaint")
 	}
 	for _, recipient := range message.Complaint.ComplainedRecipients {
 		if len(recipient.EmailAddress) == 0 {
-			t.Error("Failed to parse email address from recipient")
+			t.Error("failed to parse email address from recipient")
 		}
 	}
 }
@@ -53,11 +52,18 @@ func TestParseComplaintJSON(t *testing.T) {
 func TestSESComplaint(t *testing.T) {
 	defer teardown()
 
-	resp, err := http.Post(server.URL+"/sns", "application/json", strings.NewReader(complaintJSON))
+	_, err := http.Post(server.URL+"/sns", "application/json", strings.NewReader(complaintJSON))
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Println(resp)
+
+	blacklisted, err := api.Database.IsBlacklistedEmail("complaint@simulator.amazonses.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !blacklisted {
+		t.Error("failed to blacklist complaint email")
+	}
 }
 
 const complaintJSON = `{

--- a/email_test.go
+++ b/email_test.go
@@ -30,7 +30,7 @@ func TestRequireMissingEnvPanics(t *testing.T) {
 }
 
 func TestRequireEnvConfig(t *testing.T) {
-	_, err := makeEmailConfigFromEnv()
+	_, err := makeEmailConfigFromEnv(api.Database)
 	if err == nil {
 		t.Errorf("should have received multiple error from unset env vars")
 	}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func pingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func registerHandlers(api *API, mux *http.ServeMux) http.Handler {
-	mux.HandleFunc("/sns", handleSESNotification)
+	mux.HandleFunc("/sns", handleSESNotification(api.Database))
 
 	mux.HandleFunc("/api/scan", apiWrapper(api.Scan))
 	// Throttle the queue endpoint more aggressively so we don't send junk e-mail.
@@ -98,7 +98,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	emailConfig, err := makeEmailConfigFromEnv()
+	emailConfig, err := makeEmailConfigFromEnv(db)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ func pingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func registerHandlers(api *API, mux *http.ServeMux) http.Handler {
+	mux.HandleFunc("/sns", handleSESNotification)
+
 	mux.HandleFunc("/api/scan", apiWrapper(api.Scan))
 	// Throttle the queue endpoint more aggressively so we don't send junk e-mail.
 	mux.Handle("/api/queue",


### PR DESCRIPTION
Handles AWS Simple Email Service (SES) bounces and complaints submitted to a webhook via AWS Simple Notification Service (SNS).

Rather than verifying the signature ([something like this](https://github.com/robbiet480/go.sns/blob/master/main.go#L45-L91)) I'm checking for an API key set on SNS notification. That's how we're handling things in the Action Center and I think it's adequate for email bounce/complaint handling but let me know if you'd rather do the full verification.

Separately, we'll need to configure SNS to send notifications with the API key to this endpoint and set that key in the production env.