### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.10
 
 WORKDIR /go/src/github.com/EFForg/starttls-backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
         env_file:
           - .env.test
         environment:
-          POSTGRES_DB: $TEST_DB_NAME
-          POSTGRES_USER: $TEST_DB_USERNAME
-          POSTGRES_PASSWORD: $TEST_DB_PASSWORD
+          POSTGRES_DB: starttls_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
     app:
         build: .
         volumes:


### PR DESCRIPTION
1. Bump Go version
Closes #95 
Closes #106 

2. Set postgres_test config explicitly in the compose file. I thought these vars were getting populated by whatever file was passed to `env_file` (eg `.env.test`) but they always come from `.env`. See https://docs.docker.com/compose/environment-variables/#the-env-file