### PR TITLE
fix(test): TestRequireEnvConfig is more reliable

### DIFF
--- a/email_test.go
+++ b/email_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -27,8 +28,22 @@ func TestRequireMissingEnvPanics(t *testing.T) {
 }
 
 func TestRequireEnvConfig(t *testing.T) {
+	requiredVars := map[string]string{
+		"SMTP_USERNAME":         "",
+		"SMTP_PASSWORD":         "",
+		"SMTP_ENDPOINT":         "",
+		"SMTP_PORT":             "",
+		"SMTP_FROM_ADDRESS":     "",
+		"FRONTEND_WEBSITE_LINK": ""}
+	for varName := range requiredVars {
+		requiredVars[varName] = os.Getenv(varName)
+		os.Setenv(varName, "")
+	}
 	_, err := makeEmailConfigFromEnv()
 	if err == nil {
 		t.Errorf("should have received multiple error from unset env vars")
+	}
+	for varName, varValue := range requiredVars {
+		os.Setenv(varName, varValue)
 	}
 }


### PR DESCRIPTION
small fix that was causing some trouble on my local setup. Thought it'd be nice to have the test not rely on the system env configuration, since it's a unit-test. @vbrown608 does this look ok to you? 