### PR TITLE
validation rules match MTA-STS

### DIFF
--- a/checker/domain.go
+++ b/checker/domain.go
@@ -62,6 +62,9 @@ type DomainResult struct {
 	Status DomainStatus `json:"status"`
 	// Results of this check, on each hostname.
 	HostnameResults map[string]HostnameResult `json:"results"`
+	// The list of hostnames which will impact the Status of this result.
+	// It discards mailboxes that we can't connect to.
+	PreferredHostnames []string `json:"preferred_hostnames"`
 	// Expected MX hostnames supplied by the caller of CheckDomain.
 	MxHostnames []string `json:"mx_hostnames,omitempty"`
 	// Extra global results
@@ -145,9 +148,11 @@ func performCheck(query domainCheckQuery) DomainResult {
 			checkedHostnames = append(checkedHostnames, hostname)
 		}
 	}
+	result.PreferredHostnames = checkedHostnames
+
 	// Derive Domain code from Hostname results.
-	// We couldn't connect to any of those hostnames.
 	if len(checkedHostnames) == 0 {
+		// We couldn't connect to any of those hostnames.
 		return result.setStatus(DomainCouldNotConnect)
 	}
 	for _, hostname := range checkedHostnames {

--- a/checker/domain_test.go
+++ b/checker/domain_test.go
@@ -1,0 +1,1 @@
+package checker

--- a/checker/domain_test.go
+++ b/checker/domain_test.go
@@ -1,1 +1,138 @@
 package checker
+
+import (
+	"fmt"
+	"testing"
+)
+
+// fake DNS map for "resolving" MX lookups
+var mxLookup = map[string][]string{
+	"empty":         []string{},
+	"domain":        []string{"hostname1", "hostname2"},
+	"noconnection":  []string{"noconnection", "noconnection"},
+	"noconnection2": []string{"noconnection", "nostarttlsconnect"},
+	"nostarttls":    []string{"nostarttls", "noconnection"},
+}
+
+// Fake hostname checks :)
+var hostnameResults = map[string]HostnameResult{
+	"noconnection": HostnameResult{
+		Status: 3,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 3, nil},
+		},
+	},
+	"nostarttls": HostnameResult{
+		Status: 2,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 2, nil},
+		},
+	},
+	"nostarttlsconnect": HostnameResult{
+		Status: 3,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 3, nil},
+		},
+	},
+}
+
+// Mock query object that also fulfills the DomainQuery interface.
+type mockQuery struct {
+	Domain            string
+	ExpectedHostnames []string
+}
+
+// Mock implementation for mockQuery.
+
+func (q mockQuery) lookupHostnames() ([]string, error) {
+	if q.Domain == "error" {
+		return nil, fmt.Errorf("No MX records found")
+	}
+	return mxLookup[q.Domain], nil
+}
+
+func (q mockQuery) checkHostname(hostname string) HostnameResult {
+	if result, ok := hostnameResults[hostname]; ok {
+		return result
+	}
+	// by default return successful check
+	return HostnameResult{Status: 0, Checks: map[string]CheckResult{
+		"connectivity": {"connectivity", 0, nil},
+		"starttls":     {"starttls", 0, nil},
+		"certificate":  {"certificate", 0, nil},
+		"version":      {"version", 0, nil}}}
+}
+
+func (q mockQuery) getDomain() string {
+	return q.Domain
+}
+
+func (q mockQuery) getExpectedHostnames() []string {
+	return q.ExpectedHostnames
+}
+
+// Test helpers.
+
+// If expectedHostnames is nil, we just assume that whatever lookup occurs is correct.
+type domainTestCase struct {
+	// Test case parameters
+	domain            string
+	expectedHostnames []string
+	// Expected result of test case.
+	expect DomainStatus
+}
+
+// Perform a single test check
+func (test domainTestCase) check(t *testing.T, got DomainStatus) {
+	if got != test.expect {
+		t.Errorf("Testing %s with hostnames %s: Expected status code %d, got code %d",
+			test.domain, test.expectedHostnames, test.expect, got)
+	}
+}
+
+func performTests(t *testing.T, tests []domainTestCase) {
+	for _, test := range tests {
+		if test.expectedHostnames == nil {
+			test.expectedHostnames = mxLookup[test.domain]
+		}
+		got := performCheck(mockQuery{Domain: test.domain, ExpectedHostnames: test.expectedHostnames}).Status
+		test.check(t, got)
+	}
+}
+
+// Test cases.
+
+func TestBadMXLookup(t *testing.T) {
+	tests := []domainTestCase{
+		{"empty", []string{}, DomainCouldNotConnect},
+	}
+	performTests(t, tests)
+}
+
+func TestNoExpectedHostnames(t *testing.T) {
+	tests := []domainTestCase{
+		{"domain", []string{}, DomainBadHostnameFailure},
+		{"domain", []string{"hostname"}, DomainBadHostnameFailure},
+		{"domain", []string{"hostname1"}, DomainBadHostnameFailure},
+		{"domain", []string{"hostname1", "hostname2"}, DomainSuccess},
+		{"domain", nil, DomainSuccess},
+	}
+	performTests(t, tests)
+}
+
+func TestHostnamesNoConnection(t *testing.T) {
+	tests := []domainTestCase{
+		{domain: "noconnection", expect: DomainCouldNotConnect},
+	}
+	performTests(t, tests)
+}
+
+func TestHostnamesNoSTARTTLS(t *testing.T) {
+	tests := []domainTestCase{
+		{domain: "nostarttls", expect: DomainNoSTARTTLSFailure},
+		{domain: "noconnection2", expect: DomainNoSTARTTLSFailure},
+	}
+	performTests(t, tests)
+}

--- a/checker/domain_test.go
+++ b/checker/domain_test.go
@@ -43,14 +43,14 @@ var hostnameResults = map[string]HostnameResult{
 type mockLookup struct{}
 type mockChecker struct{}
 
-func (*mockLookup) lookup(domain string) ([]string, error) {
+func (*mockLookup) lookupHostname(domain string) ([]string, error) {
 	if domain == "error" {
 		return nil, fmt.Errorf("No MX records found")
 	}
 	return mxLookup[domain], nil
 }
 
-func (*mockChecker) check(domain string, hostname string) HostnameResult {
+func (*mockChecker) checkHostname(domain string, hostname string) HostnameResult {
 	if result, ok := hostnameResults[hostname]; ok {
 		return result
 	}

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -12,11 +12,10 @@ import (
 
 // HostnameResult wraps the results of a security check against a particular hostname.
 type HostnameResult struct {
-	Domain      string                 `json:"domain"`
-	Hostname    string                 `json:"hostname"`
-	MxHostnames []string               `json:"mx_hostnames,omitempty"`
-	Status      CheckStatus            `json:"status"`
-	Checks      map[string]CheckResult `json:"checks"`
+	Domain   string                 `json:"domain"`
+	Hostname string                 `json:"hostname"`
+	Status   CheckStatus            `json:"status"`
+	Checks   map[string]CheckResult `json:"checks"`
 }
 
 // Returns result of specifiedcheck.
@@ -70,12 +69,12 @@ func policyMatch(certName string, policyMx string) bool {
 // Checks certificate names against a list of expected MX patterns.
 // The expected MX patterns are in the format described by MTA-STS,
 // and validation is done according to this RFC as well.
-func hasValidName(certNames []string, mxs []string) bool {
-	for _, mx := range mxs {
-		for _, certName := range certNames {
-			if policyMatch(certName, mx) {
-				return true
-			}
+func hasValidName(names []string, hostname string) bool {
+	// If FQDN, might end with '.'; strip it!
+	hostname = strings.TrimSuffix(hostname, ".")
+	for _, name := range names {
+		if policyMatch(name, hostname) {
+			return true
 		}
 	}
 	return false
@@ -163,18 +162,15 @@ var certRoots *x509.CertPool
 
 // Checks that the certificate presented is valid for a particular hostname, unexpired,
 // and chains to a trusted root.
-func checkCert(client *smtp.Client, domain, hostname string, mxHostnames []string) CheckResult {
+func checkCert(client *smtp.Client, domain, hostname string) CheckResult {
 	result := CheckResult{Name: "certificate"}
 	state, ok := client.TLSConnectionState()
 	if !ok {
 		return result.Error("TLS not initiated properly.")
 	}
 	cert := state.PeerCertificates[0]
-	if len(mxHostnames) == 0 {
-		mxHostnames = defaultValidMX(domain, hostname)
-	}
-	if !hasValidName(getNamesFromCert(cert), mxHostnames) {
-		result = result.Failure("Name in cert doesn't match any MX hostnames.")
+	if !hasValidName(getNamesFromCert(cert), hostname) {
+		result = result.Failure("Name in cert doesn't match hostname.")
 	}
 	err := verifyCertChain(state)
 	if err != nil {
@@ -251,15 +247,12 @@ func (h *HostnameResult) addCheck(checkResult CheckResult) {
 // CheckHostname performs a series of checks against a hostname for an email domain.
 // `domain` is the mail domain that this server serves email for.
 // `hostname` is the hostname for this server.
-// `mxHostnames` is a list of MX patterns that `hostname` (and the associated TLS certificate)
-//     can be valid for. If this is nil, then defaults to [`domain`, `hostname`].
-func CheckHostname(domain string, hostname string, mxHostnames []string) HostnameResult {
+func CheckHostname(domain string, hostname string) HostnameResult {
 	result := HostnameResult{
-		Status:      Success,
-		Domain:      domain,
-		Hostname:    hostname,
-		MxHostnames: mxHostnames,
-		Checks:      make(map[string]CheckResult),
+		Status:   Success,
+		Domain:   domain,
+		Hostname: hostname,
+		Checks:   make(map[string]CheckResult),
 	}
 
 	// Connect to the SMTP server and use that connection to perform as many checks as possible.
@@ -276,7 +269,7 @@ func CheckHostname(domain string, hostname string, mxHostnames []string) Hostnam
 	if result.Status != Success {
 		return result
 	}
-	result.addCheck(checkCert(client, domain, hostname, mxHostnames))
+	result.addCheck(checkCert(client, domain, hostname))
 	// result.addCheck(checkTLSCipher(hostname))
 
 	// Creates a new connection to check for SSLv2/3 support because we can't call starttls twice.

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -66,12 +66,18 @@ func policyMatch(certName string, policyMx string) bool {
 		wildcardMatch(policyMx, certName)
 }
 
+func withoutPort(url string) string {
+	return url[0:strings.LastIndex(url, ":")]
+}
+
 // Checks certificate names against a list of expected MX patterns.
 // The expected MX patterns are in the format described by MTA-STS,
 // and validation is done according to this RFC as well.
 func hasValidName(names []string, hostname string) bool {
 	// If FQDN, might end with '.'; strip it!
 	hostname = strings.TrimSuffix(hostname, ".")
+	// If URL, might include port #; strip it!
+	hostname = withoutPort(hostname)
 	for _, name := range names {
 		if policyMatch(name, hostname) {
 			return true

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -67,7 +67,10 @@ func policyMatch(certName string, policyMx string) bool {
 }
 
 func withoutPort(url string) string {
-	return url[0:strings.LastIndex(url, ":")]
+	if strings.Contains(url, ":") {
+		return url[0:strings.LastIndex(url, ":")]
+	}
+	return url
 }
 
 // Checks certificate names against a list of expected MX patterns.

--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -53,7 +53,7 @@ func TestPolicyMatch(t *testing.T) {
 }
 
 func TestNoConnection(t *testing.T) {
-	result := CheckHostname("", "example.com", nil)
+	result := CheckHostname("", "example.com")
 
 	expected := HostnameResult{
 		Status: 3,
@@ -68,7 +68,7 @@ func TestNoTLS(t *testing.T) {
 	ln := smtpListenAndServe(t, &tls.Config{})
 	defer ln.Close()
 
-	result := CheckHostname("", ln.Addr().String(), nil)
+	result := CheckHostname("", ln.Addr().String())
 
 	expected := HostnameResult{
 		Status: 2,
@@ -88,7 +88,7 @@ func TestSelfSigned(t *testing.T) {
 	ln := smtpListenAndServe(t, &tls.Config{Certificates: []tls.Certificate{cert}})
 	defer ln.Close()
 
-	result := CheckHostname("", ln.Addr().String(), nil)
+	result := CheckHostname("", ln.Addr().String())
 
 	expected := HostnameResult{
 		Status: 2,
@@ -114,7 +114,7 @@ func TestNoTLS12(t *testing.T) {
 	})
 	defer ln.Close()
 
-	result := CheckHostname("", ln.Addr().String(), nil)
+	result := CheckHostname("", ln.Addr().String())
 
 	expected := HostnameResult{
 		Status: 2,
@@ -142,13 +142,46 @@ func TestSuccessWithFakeCA(t *testing.T) {
 		certRoots = nil
 	}()
 
-	result := CheckHostname("", ln.Addr().String(), nil)
+	addrParts := strings.Split(ln.Addr().String(), ":")
+	port := addrParts[len(addrParts)-1]
+
+	result := CheckHostname("", strings.Join([]string{"localhost", port}, ":"))
 	expected := HostnameResult{
 		Status: 0,
 		Checks: map[string]CheckResult{
 			"connectivity": {"connectivity", 0, nil},
 			"starttls":     {"starttls", 0, nil},
 			"certificate":  {"certificate", 0, nil},
+			"version":      {"version", 0, nil},
+		},
+	}
+	compareStatuses(t, expected, result)
+}
+
+func TestFailureWithBadHostname(t *testing.T) {
+	cert, err := tls.X509KeyPair([]byte(certString), []byte(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln := smtpListenAndServe(t, &tls.Config{Certificates: []tls.Certificate{cert}})
+	defer ln.Close()
+
+	certRoots, _ = x509.SystemCertPool()
+	certRoots.AppendCertsFromPEM([]byte(certStringHostnameMismatch))
+	defer func() {
+		certRoots = nil
+	}()
+
+	addrParts := strings.Split(ln.Addr().String(), ":")
+	port := addrParts[len(addrParts)-1]
+
+	result := CheckHostname("", strings.Join([]string{"localhost", port}, ":"))
+	expected := HostnameResult{
+		Status: 2,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 0, nil},
+			"certificate":  {"certificate", 2, nil},
 			"version":      {"version", 0, nil},
 		},
 	}
@@ -182,7 +215,7 @@ func TestAdvertisedCiphers(t *testing.T) {
 
 	ln := smtpListenAndServe(t, tlsConfig)
 	defer ln.Close()
-	CheckHostname("", ln.Addr().String(), nil)
+	CheckHostname("", ln.Addr().String())
 
 	// Partial list of ciphers we want to support
 	expectedCipherSuites := []struct {
@@ -254,11 +287,28 @@ func smtpListenAndServe(t *testing.T, tlsConfig *tls.Config) net.Listener {
 
 func noopHandler(_ net.Addr, _ string, _ []string, _ []byte) {}
 
-// Commands to generate the self-signed certificate below:
+// Commands to generate the self-signed certificates below:
 //	openssl req -new -key server.key -out server.csr
 //	openssl x509 -req -in server.csr -signkey server.key -out server.crt
+// certString was created with a CN of "localhost"; certStringHostnameMismatch
+// has an empty/no CN.
 
 const certString = `-----BEGIN CERTIFICATE-----
+MIICKTCCAZICCQDPUsAOcVJx1jANBgkqhkiG9w0BAQsFADBZMQswCQYDVQQGEwJB
+VTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0
+cyBQdHkgTHRkMRIwEAYDVQQDDAlsb2NhbGhvc3QwHhcNMTgwODIzMTkxOTA5WhcN
+MTgwOTIyMTkxOTA5WjBZMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0
+ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRIwEAYDVQQDDAls
+b2NhbGhvc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALsGFO2tmSAPtDR8
+YccGXhNGsQU7YqY33cxVl1OhvZLefBawVSho/0nHhaxDQX4zA/acpNLnYu9MKo/I
+P1UWn1dLnYy2rpzKUr5ROQoBCdJW7XiDl1LSABsz3XjPE7U0Wn/0LiIKLSpopbM8
+IYsIgSiqRvv4eVhB6QGQkdHdPOrdAgMBAAEwDQYJKoZIhvcNAQELBQADgYEAPnEv
+WWNtNYJJmTQAzVUmYmuVQB1Fff9k8Cw1lrkQotmc8G/LVICeaec84Bcr1hYc7LJ4
+SBp7ymERslpEeZCrFiAG/hMB+icCpPdbbAkjVW3/Yo2/SgKhak7iZvszme1NraZm
+BlzuYy3PFsuUU45cRIPBsoygZ498JwrVn9/WeAM=
+-----END CERTIFICATE-----`
+
+const certStringHostnameMismatch = `-----BEGIN CERTIFICATE-----
 MIIBkDCB+gIJAP/G75+MvzSQMA0GCSqGSIb3DQEBBQUAMA0xCzAJBgNVBAYTAlVT
 MB4XDTE4MDcyNjE2NDM0MloXDTE4MDgyNTE2NDM0MlowDTELMAkGA1UEBhMCVVMw
 gZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALsGFO2tmSAPtDR8YccGXhNGsQU7

--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -145,8 +145,9 @@ func TestSuccessWithFakeCA(t *testing.T) {
 	// Our test cert happens to be valid for hostname "localhost",
 	// so here we replace the loopback address with "localhost" while
 	// conserving the port number.
-	port := strings.TrimPrefix(ln.Addr().String(), "127.0.0.1")
-	result := CheckHostname("", "localhost"+port)
+	addrParts := strings.Split(ln.Addr().String(), ":")
+	port := addrParts[len(addrParts)-1]
+	result := CheckHostname("", "localhost:"+port)
 	expected := HostnameResult{
 		Status: 0,
 		Checks: map[string]CheckResult{
@@ -176,8 +177,9 @@ func TestFailureWithBadHostname(t *testing.T) {
 	// Our test cert happens to be valid for hostname "localhost",
 	// so here we replace the loopback address with "localhost" while
 	// conserving the port number.
-	port := strings.TrimPrefix(ln.Addr().String(), "127.0.0.1")
-	result := CheckHostname("", "localhost"+port)
+	addrParts := strings.Split(ln.Addr().String(), ":")
+	port := addrParts[len(addrParts)-1]
+	result := CheckHostname("", "localhost:"+port)
 	expected := HostnameResult{
 		Status: 2,
 		Checks: map[string]CheckResult{

--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -142,10 +142,11 @@ func TestSuccessWithFakeCA(t *testing.T) {
 		certRoots = nil
 	}()
 
-	addrParts := strings.Split(ln.Addr().String(), ":")
-	port := addrParts[len(addrParts)-1]
-
-	result := CheckHostname("", strings.Join([]string{"localhost", port}, ":"))
+	// Our test cert happens to be valid for hostname "localhost",
+	// so here we replace the loopback address with "localhost" while
+	// conserving the port number.
+	port := strings.TrimPrefix(ln.Addr().String(), "127.0.0.1")
+	result := CheckHostname("", "localhost"+port)
 	expected := HostnameResult{
 		Status: 0,
 		Checks: map[string]CheckResult{
@@ -172,10 +173,11 @@ func TestFailureWithBadHostname(t *testing.T) {
 		certRoots = nil
 	}()
 
-	addrParts := strings.Split(ln.Addr().String(), ":")
-	port := addrParts[len(addrParts)-1]
-
-	result := CheckHostname("", strings.Join([]string{"localhost", port}, ":"))
+	// Our test cert happens to be valid for hostname "localhost",
+	// so here we replace the loopback address with "localhost" while
+	// conserving the port number.
+	port := strings.TrimPrefix(ln.Addr().String(), "127.0.0.1")
+	result := CheckHostname("", "localhost"+port)
 	expected := HostnameResult{
 		Status: 2,
 		Checks: map[string]CheckResult{
@@ -268,7 +270,7 @@ func smtpListenAndServe(t *testing.T, tlsConfig *tls.Config) net.Listener {
 	}
 	srv.TLSConfig = tlsConfig
 
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fixes #105 

> 
> The current version of this tool checks that the presented cert is valid for at least one of the names specified in `mx-hostnames`.
> 
> The new validation rules specify that:
> 1. The selected MX host matches at least one of the `mx-hostnames` patterns, and that
> 2. The presented certificate is valid for the hostname.
> 

I had to move the `mxHostnames` (which I renamed `expectedHostnames` in some parts of the code, to be slightly more clear) check to the domain-level check! Which also involved writing tests for `domain.go`.

Two notes:
 - I did a little bit of refactoring in `domain.go` so we could test it sanely.
 - This changes the API, as I noted in issue #105. It's not a big change, but we should use it to talk about how we want to roll out API changes in general :)