### PR TITLE
testfix: regen checker cert for each test run

### DIFF
--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -35,7 +35,6 @@ func createCert(keyData string, commonName string) string {
 		NotAfter:     time.Now().Add(time.Minute),
 		IsCA:         true,
 		DNSNames:     []string{commonName},
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 	}
 	certDER, _ := x509.CreateCertificate(rand.Reader, &template, &template, &(privKey.PublicKey), privKey)
 	// 3. Convert cert to PEM format (for consumption by crypto/tls)


### PR DESCRIPTION
fixes #114 forever.
more permanent than fix in #115; however #115 can (and should be) landed ASAP. this should undergo more thorough review.

`createCert` scraped pieces from [crypto/tls/generate_cert.go](http://golang.org/src/pkg/crypto/tls/generate_cert.go) and [`X509KeyPair`](https://golang.org/src/crypto/tls/tls.go?s=5915:5986#L183) from the same package. I'm being sloppy with the DER <-> PEM parsing errors since it's a test fn and it's deterministic; but let me know if you'd prefer we forward them to a `t.Fatal`.