### PR TITLE
Authed endpoint for retrieving list

### DIFF
--- a/api.go
+++ b/api.go
@@ -49,6 +49,7 @@ type API struct {
 // for a particular domain.
 type PolicyList interface {
 	Get(string) (policy.TLSPolicy, error)
+	Raw() policy.List
 }
 
 // EmailSender interface wraps a back-end that can send e-mails.

--- a/list_api.go
+++ b/list_api.go
@@ -33,12 +33,9 @@ func getNumberParam(r *http.Request, paramName string, defaultNumber int) int {
 func (api API) GetList(r *http.Request) APIResponse {
 	expire_weeks := getNumberParam(r, "expire_weeks", 2)
 	queued_weeks := getNumberParam(r, "queued_weeks", 1)
-	list, err := policy.FetchListHTTP()
+	list := api.List.Raw()
 	list.Timestamp = time.Now()
 	list.Expires = list.Timestamp.Add(time.Hour * 24 * 7 * time.Duration(expire_weeks))
-	if err != nil {
-		return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
-	}
 	queued, err := api.Database.GetDomains(db.StateQueued)
 	if err != nil {
 		return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}

--- a/list_api.go
+++ b/list_api.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/EFForg/starttls-backend/db"
+	"github.com/EFForg/starttls-backend/policy"
+)
+
+////////////////////////////////
+//  *****   LIST API   *****  //
+////////////////////////////////
+
+func getNumberParam(r *http.Request, paramName string, defaultNumber int) int {
+	numStr, err := getParam(paramName, r)
+	result := defaultNumber
+	if err == nil {
+		if n, err := strconv.Atoi(numStr); err == nil {
+			result = n
+		}
+	}
+	return result
+}
+
+// GetList generates a new JSON file, with all queued entries!
+//   GET /auth/list
+//       expire_weeks: after how many weeks should this list expire? If unset
+//                     or invalid, defaults to 2. If set to 0, expires immediately.
+//       queued_weeks: for at least how many weeks should domains on the resulting list
+//                     have been queued? if unset or invalid, defaults to 1.
+func (api API) GetList(r *http.Request) APIResponse {
+	expire_weeks := getNumberParam(r, "expire_weeks", 2)
+	queued_weeks := getNumberParam(r, "queued_weeks", 1)
+	list, err := policy.FetchListHTTP()
+	list.Timestamp = time.Now()
+	list.Expires = list.Timestamp.Add(time.Hour * 24 * 7 * time.Duration(expire_weeks))
+	if err != nil {
+		return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
+	}
+	queued, err := api.Database.GetDomains(db.StateQueued)
+	if err != nil {
+		return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
+	}
+	cutoffTime := time.Now().Add(-time.Hour * 24 * 7 * time.Duration(queued_weeks))
+	for _, domainData := range queued {
+		if domainData.LastUpdated.After(cutoffTime) {
+			continue
+		}
+		list.Add(domainData.Name, policy.TLSPolicy{
+			Mode: "enforce",
+			MXs:  domainData.MXs,
+		})
+	}
+	return APIResponse{StatusCode: http.StatusOK, Response: list}
+}

--- a/list_api.go
+++ b/list_api.go
@@ -31,16 +31,16 @@ func getNumberParam(r *http.Request, paramName string, defaultNumber int) int {
 //       queued_weeks: for at least how many weeks should domains on the resulting list
 //                     have been queued? if unset or invalid, defaults to 1.
 func (api API) GetList(r *http.Request) APIResponse {
-	expire_weeks := getNumberParam(r, "expire_weeks", 2)
-	queued_weeks := getNumberParam(r, "queued_weeks", 1)
+	expireWeeks := getNumberParam(r, "expire_weeks", 2)
+	queuedWeeks := getNumberParam(r, "queued_weeks", 1)
 	list := api.List.Raw()
 	list.Timestamp = time.Now()
-	list.Expires = list.Timestamp.Add(time.Hour * 24 * 7 * time.Duration(expire_weeks))
+	list.Expires = list.Timestamp.Add(time.Hour * 24 * 7 * time.Duration(expireWeeks))
 	queued, err := api.Database.GetDomains(db.StateQueued)
 	if err != nil {
 		return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
 	}
-	cutoffTime := time.Now().Add(-time.Hour * 24 * 7 * time.Duration(queued_weeks))
+	cutoffTime := time.Now().Add(-time.Hour * 24 * 7 * time.Duration(queuedWeeks))
 	for _, domainData := range queued {
 		if domainData.LastUpdated.After(cutoffTime) {
 			continue

--- a/list_api_test.go
+++ b/list_api_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/EFForg/starttls-backend/db"
+	"github.com/EFForg/starttls-backend/policy"
+)
+
+func TestGetListBasic(t *testing.T) {
+	defer teardown()
+	resp, _ := http.Get(server.URL + "/auth/list")
+	body, _ := ioutil.ReadAll(resp.Body)
+	var list policy.List
+	json.Unmarshal(body, &APIResponse{Response: &list})
+	if _, ok := list.Policies["eff.org"]; !ok {
+		t.Errorf("Expected eff.org to be on mock policy list")
+	}
+}
+
+func queueDomain(domain string) {
+	api.Database.PutDomain(db.DomainData{
+		Name:  "example.com",
+		Email: "postmaster@example.com",
+		MXs:   []string{"a.b.c"}})
+	api.Database.PutDomain(db.DomainData{
+		Name: "example.com", State: db.StateQueued})
+}
+
+func TestGetListWithQueuedDomainsAdded(t *testing.T) {
+	defer teardown()
+	queueDomain("example.com")
+	resp, _ := http.Get(server.URL + "/auth/list?queued_weeks=0")
+	body, _ := ioutil.ReadAll(resp.Body)
+	var list policy.List
+	json.Unmarshal(body, &APIResponse{Response: &list})
+	if _, ok := list.Policies["example.com"]; !ok {
+		t.Errorf("Expected example.com to be on mock policy list")
+	}
+}
+
+func TestGetListNewQueuedDomainsNotAdded(t *testing.T) {
+	defer teardown()
+	queueDomain("example.com")
+	resp, _ := http.Get(server.URL + "/auth/list?queued_weeks=1")
+	body, _ := ioutil.ReadAll(resp.Body)
+	var list policy.List
+	json.Unmarshal(body, &APIResponse{Response: &list})
+	if _, ok := list.Policies["example.com"]; ok {
+		t.Errorf("Did not expect example.com to be on mock policy list")
+	}
+}
+
+func TestGetListExpiryTime(t *testing.T) {
+	defer teardown()
+	lowerBound := time.Now().Add(4 * 7 * 24 * time.Hour)
+	resp, _ := http.Get(server.URL + "/auth/list?expire_weeks=4")
+	upperBound := time.Now().Add(4 * 7 * 24 * time.Hour)
+	body, _ := ioutil.ReadAll(resp.Body)
+	var list policy.List
+	json.Unmarshal(body, &APIResponse{Response: &list})
+	if list.Expires.Before(lowerBound) {
+		t.Errorf("list expires too early")
+	}
+	if list.Expires.After(upperBound) {
+		t.Errorf("list expires too late")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func registerHandlers(api *API, mux *http.ServeMux) http.Handler {
 		throttleHandler(time.Hour, 3, http.HandlerFunc(apiWrapper(api.Queue))))
 	mux.HandleFunc("/api/validate", apiWrapper(api.Validate))
 	mux.HandleFunc("/api/ping", pingHandler)
+	mux.HandleFunc("/auth/list", apiWrapper(api.GetList))
 
 	return middleware(mux)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
 	"github.com/EFForg/starttls-backend/db"
@@ -28,6 +29,23 @@ func mockCheckPerform(message string) func(API, string) (checker.DomainResult, e
 // Mock PolicyList
 type mockList struct {
 	domains map[string]bool
+}
+
+func (l mockList) Raw() policy.List {
+	list := policy.List{
+		Timestamp:     time.Now(),
+		Expires:       time.Now().Add(time.Minute),
+		Version:       "",
+		Author:        "",
+		Pinsets:       make(map[string]policy.Pinset),
+		PolicyAliases: make(map[string]policy.TLSPolicy),
+		Policies:      make(map[string]policy.TLSPolicy),
+	}
+	for domain := range l.domains {
+		list.Policies[domain] =
+			policy.TLSPolicy{Mode: "enforce", MXs: []string{"mx.fake.com"}}
+	}
+	return list
 }
 
 func (l mockList) Get(domain string) (policy.TLSPolicy, error) {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -106,21 +106,18 @@ func (l UpdatedList) Get(domain string) (TLSPolicy, error) {
 func (l UpdatedList) Raw() List {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	list := List{
-		Timestamp:     l.Timestamp,
-		Expires:       l.Expires,
-		Version:       l.Version,
-		Author:        l.Author,
-		Pinsets:       make(map[string]Pinset),
-		PolicyAliases: make(map[string]TLSPolicy),
-		Policies:      make(map[string]TLSPolicy),
-	}
+	list := l.List
+	list.Timestamp = l.Timestamp
+	list.Expires = l.Expires
+	list.Pinsets = make(map[string]Pinset)
 	for pinName, pinset := range l.Pinsets {
 		list.Pinsets[pinName] = pinset.clone()
 	}
+	list.PolicyAliases = make(map[string]TLSPolicy)
 	for alias, policy := range l.PolicyAliases {
 		list.PolicyAliases[alias] = policy.clone()
 	}
+	list.Policies = make(map[string]TLSPolicy)
 	for domain, policy := range l.Policies {
 		list.Policies[domain] = policy.clone()
 	}
@@ -136,14 +133,8 @@ func (p Pinset) clone() Pinset {
 }
 
 func (p TLSPolicy) clone() TLSPolicy {
-	policy := TLSPolicy{
-		PolicyAlias:   p.PolicyAlias,
-		MinTLSVersion: p.MinTLSVersion,
-		Mode:          p.Mode,
-		Pin:           p.Pin,
-		Report:        p.Report,
-		MXs:           make([]string, 0),
-	}
+	policy := p
+	policy.MXs = make([]string, 0)
 	for _, mx := range p.MXs {
 		policy.MXs = append(policy.MXs, mx)
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -197,5 +197,5 @@ func makeUpdatedList(fetch fetchListFn, updateFrequency time.Duration) UpdatedLi
 
 // MakeUpdatedList wraps makeUpdatedList to use FetchListHTTP by default to update policy list
 func MakeUpdatedList() UpdatedList {
-	return makeUpdatedList(FetchListHTTP, time.Hour)
+	return makeUpdatedList(fetchListHTTP, time.Hour)
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -23,14 +23,14 @@ type Pinset struct {
 type TLSPolicy struct {
 	PolicyAlias   string   `json:"policy-alias,omitempty"`
 	MinTLSVersion string   `json:"min-tls-version,omitempty"`
-	Mode          string   `json:"mode"`
-	MXs           []string `json:"mxs"`
+	Mode          string   `json:"mode,omitempty"`
+	MXs           []string `json:"mxs,omitempty"`
 	Pin           string   `json:"pin,omitempty"`
 	Report        string   `json:"report,omitempty"`
 }
 
 // List is a raw representation of the policy list.
-type list struct {
+type List struct {
 	Timestamp     time.Time            `json:"timestamp"`
 	Expires       time.Time            `json:"expires"`
 	Version       string               `json:"version"`
@@ -40,9 +40,13 @@ type list struct {
 	Policies      map[string]TLSPolicy `json:"policies"`
 }
 
+func (l *List) Add(domain string, policy TLSPolicy) {
+	l.Policies[domain] = policy
+}
+
 // get retrieves the TLSPolicy for a domain, and resolves
 // aliases if they exist.
-func (l list) get(domain string) (TLSPolicy, error) {
+func (l List) get(domain string) (TLSPolicy, error) {
 	policy, ok := l.Policies[domain]
 	if !ok {
 		return TLSPolicy{}, fmt.Errorf("policy for domain %s doesn't exist", domain)
@@ -60,7 +64,7 @@ func (l list) get(domain string) (TLSPolicy, error) {
 // policyURL every hour. Safe for concurrent calls to `Get`.
 type UpdatedList struct {
 	mu sync.RWMutex
-	list
+	List
 }
 
 // DomainsToValidate [interface Validator] retrieves domains from the
@@ -98,20 +102,20 @@ func (l UpdatedList) Get(domain string) (TLSPolicy, error) {
 }
 
 // fetchListFn returns a new policy list. It can be used to update UpdatedList
-type fetchListFn func() (list, error)
+type fetchListFn func() (List, error)
 
 // Retrieve and parse List from policyURL
-func fetchListHTTP() (list, error) {
+func FetchListHTTP() (List, error) {
 	resp, err := http.Get(policyURL)
 	if err != nil {
-		return list{}, err
+		return List{}, err
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
-	var policyList list
+	var policyList List
 	err = json.Unmarshal(body, &policyList)
 	if err != nil {
-		return list{}, err
+		return List{}, err
 	}
 	return policyList, nil
 }
@@ -123,7 +127,7 @@ func (l *UpdatedList) update(fetch fetchListFn) {
 		log.Printf("Error updating policy list: %s\n", err)
 	} else {
 		l.mu.Lock()
-		l.list = newList
+		l.List = newList
 		l.mu.Unlock()
 	}
 }
@@ -146,5 +150,5 @@ func makeUpdatedList(fetch fetchListFn, updateFrequency time.Duration) UpdatedLi
 
 // MakeUpdatedList wraps makeUpdatedList to use FetchListHTTP by default to update policy list
 func MakeUpdatedList() UpdatedList {
-	return makeUpdatedList(fetchListHTTP, time.Hour)
+	return makeUpdatedList(FetchListHTTP, time.Hour)
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -40,6 +40,7 @@ type List struct {
 	Policies      map[string]TLSPolicy `json:"policies"`
 }
 
+// Add adds a particular domain's policy to the list.
 func (l *List) Add(domain string, policy TLSPolicy) {
 	l.Policies[domain] = policy
 }
@@ -101,6 +102,7 @@ func (l UpdatedList) Get(domain string) (TLSPolicy, error) {
 	return l.get(domain)
 }
 
+// Raw returns a raw List struct, copied from the underlying one
 func (l UpdatedList) Raw() List {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -7,29 +7,29 @@ import (
 	"time"
 )
 
-var mockList = list{
+var mockList = List{
 	Policies: map[string]TLSPolicy{
 		"eff.org": TLSPolicy{Mode: "testing"},
 	},
 }
 
-func mockFetchHTTP() (list, error) {
+func mockFetchHTTP() (List, error) {
 	return mockList, nil
 }
 
-func mockErroringFetchHTTP() (list, error) {
-	return list{}, fmt.Errorf("something went wrong")
+func mockErroringFetchHTTP() (List, error) {
+	return List{}, fmt.Errorf("something went wrong")
 }
 
 func TestGetPolicy(t *testing.T) {
-	list := makeUpdatedList(mockFetchHTTP, time.Hour)
+	List := makeUpdatedList(mockFetchHTTP, time.Hour)
 
-	policy, err := list.Get("not-on-the-list.com")
+	policy, err := List.Get("not-on-the-List.com")
 	if err == nil {
-		t.Error("Getting the policy for an unlisted domain should return an error")
+		t.Error("Getting the policy for an unListed domain should return an error")
 	}
 
-	policy, err = list.Get("eff.org")
+	policy, err = List.Get("eff.org")
 	if err != nil {
 		t.Errorf("Unexpected error while getting policy: %s", err)
 	}
@@ -39,24 +39,24 @@ func TestGetPolicy(t *testing.T) {
 }
 
 func TestFailedListUpdate(t *testing.T) {
-	list := makeUpdatedList(mockErroringFetchHTTP, time.Hour)
-	_, err := list.Get("eff.org")
+	List := makeUpdatedList(mockErroringFetchHTTP, time.Hour)
+	_, err := List.Get("eff.org")
 	if err == nil {
-		t.Errorf("Get should return an error if fetching the list fails")
+		t.Errorf("Get should return an error if fetching the List fails")
 	}
 }
 
 func TestListUpdate(t *testing.T) {
-	var updatedList = list{Policies: map[string]TLSPolicy{}}
-	list := makeUpdatedList(func() (list, error) { return updatedList, nil }, time.Second)
-	_, err := list.Get("example.com")
+	var updatedList = List{Policies: map[string]TLSPolicy{}}
+	List := makeUpdatedList(func() (List, error) { return updatedList, nil }, time.Second)
+	_, err := List.Get("example.com")
 	if err == nil {
-		t.Error("Getting the policy for an unlisted domain should return an error")
+		t.Error("Getting the policy for an unListed domain should return an error")
 	}
-	// Update the list!
+	// Update the List!
 	updatedList.Policies["example.com"] = TLSPolicy{Mode: "testing"}
 	time.Sleep(time.Second * 2)
-	policy, err := list.Get("example.com")
+	policy, err := List.Get("example.com")
 	if err != nil {
 		t.Errorf("Unexpected error while getting policy: %s", err)
 	}
@@ -66,12 +66,12 @@ func TestListUpdate(t *testing.T) {
 }
 
 func TestDomainsToValidate(t *testing.T) {
-	var updatedList = list{Policies: map[string]TLSPolicy{
+	var updatedList = List{Policies: map[string]TLSPolicy{
 		"eff.org":     TLSPolicy{},
 		"example.com": TLSPolicy{},
 	}}
-	list := makeUpdatedList(func() (list, error) { return updatedList, nil }, time.Second)
-	domains, _ := list.DomainsToValidate()
+	List := makeUpdatedList(func() (List, error) { return updatedList, nil }, time.Second)
+	domains, _ := List.DomainsToValidate()
 	if !reflect.DeepEqual([]string{"eff.org", "example.com"}, domains) {
 		t.Errorf("Expected eff.org and example.com to be returned")
 	}
@@ -79,10 +79,10 @@ func TestDomainsToValidate(t *testing.T) {
 
 func TestHostnamesForDomain(t *testing.T) {
 	hostnames := []string{"a", "b", "c"}
-	var updatedList = list{Policies: map[string]TLSPolicy{
+	var updatedList = List{Policies: map[string]TLSPolicy{
 		"eff.org": TLSPolicy{MXs: hostnames}}}
-	list := makeUpdatedList(func() (list, error) { return updatedList, nil }, time.Second)
-	returned, err := list.HostnamesForDomain("eff.org")
+	List := makeUpdatedList(func() (List, error) { return updatedList, nil }, time.Second)
+	returned, err := List.HostnamesForDomain("eff.org")
 	if err != nil {
 		t.Fatalf("Encountered %v", err)
 	}


### PR DESCRIPTION
fixes #123 
`/auth/list` works and has been tested ~now need to finish testing `/auth/sync`.~
EDIT: Decided to fix this up to only include the `/auth/list` endpoint. `/auth/sync` will come in a future PR.
Sub-part of #6 