### PR TITLE
list mgmt: fail/promote domains

### DIFF
--- a/list_api.go
+++ b/list_api.go
@@ -57,7 +57,6 @@ func (api API) GetList(r *http.Request) APIResponse {
 //
 // POST /auth/fail
 //      domain: Domain name to demote to "failed" state
-//      reason: Human-text reasoning for why domain was demoted and how it failed
 func (api API) FailDomain(r *http.Request) APIResponse {
 	if r.Method != http.MethodPost {
 		return APIResponse{StatusCode: http.StatusMethodNotAllowed,

--- a/list_api.go
+++ b/list_api.go
@@ -52,3 +52,26 @@ func (api API) GetList(r *http.Request) APIResponse {
 	}
 	return APIResponse{StatusCode: http.StatusOK, Response: list}
 }
+
+// POST /auth/fail?domain=<domain>
+func (api API) FailDomain(r *http.Request) APIResponse {
+	if r.Method != http.MethodPost {
+		return APIResponse{StatusCode: http.StatusMethodNotAllowed,
+			Message: "/auth/fail only accepts POST requests"}
+	}
+	domain, err := getParam("domain", r)
+	if err != nil {
+		return APIResponse{StatusCode: http.StatusBadRequest, Message: "parameter domain is required"}
+	}
+	if _, err := api.Database.GetDomain(domain); err != nil {
+		return APIResponse{StatusCode: http.StatusBadRequest, Message: "domain " + domain + " not in database"}
+	}
+	err = api.Database.PutDomain(db.DomainData{
+		Name:  domain,
+		State: db.StateFailed,
+	})
+	if err != nil {
+		return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
+	}
+	return APIResponse{StatusCode: http.StatusOK}
+}

--- a/list_api_test.go
+++ b/list_api_test.go
@@ -31,6 +31,25 @@ func queueDomain(domain string) {
 		Name: domain, State: db.StateQueued})
 }
 
+func expectDomainState(t *testing.T, domain string, expectedState db.DomainState) {
+	resp, _ := http.Get(server.URL + "/api/queue?domain=" + domain)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected domain get to succeed")
+	}
+	domainBody, _ := ioutil.ReadAll(resp.Body)
+	domainData := db.DomainData{}
+	err := json.Unmarshal(domainBody, &APIResponse{Response: &domainData})
+	if err != nil {
+		t.Fatalf("returned invalid JSON object:%v\n", string(domainBody))
+	}
+	if domainData.Name != domain {
+		t.Errorf("should have retrieved info for %s,  not %s\n", domain, domainData.Name)
+	}
+	if domainData.State != expectedState {
+		t.Errorf("expected state to be StateAdded, got %v\n", domainData.State)
+	}
+}
+
 func TestGetListWithQueuedDomainsAdded(t *testing.T) {
 	defer teardown()
 	queueDomain("example.com")
@@ -86,22 +105,7 @@ func TestFailDomain(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected domain update to succeed")
 	}
-	resp, _ = http.Get(server.URL + "/api/queue?domain=example.com")
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected domain get to succeed")
-	}
-	domainBody, _ := ioutil.ReadAll(resp.Body)
-	domainData := db.DomainData{}
-	err := json.Unmarshal(domainBody, &APIResponse{Response: &domainData})
-	if err != nil {
-		t.Fatalf("returned invalid JSON object:%v\n", string(domainBody))
-	}
-	if domainData.Name != "example.com" {
-		t.Errorf("should have retrieved info for example.com, not %s\n", domainData.Name)
-	}
-	if domainData.State != db.StateFailed {
-		t.Errorf("expected state to be StateFailed, got %v\n", domainData.State)
-	}
+	expectDomainState(t, "example.com", db.StateFailed)
 }
 
 func TestFailDomainNoGets(t *testing.T) {
@@ -110,4 +114,23 @@ func TestFailDomainNoGets(t *testing.T) {
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Errorf("expected 4** Method Not Allowed since /auth/fail only accepts POSTs")
 	}
+}
+
+func TestSyncListNoGets(t *testing.T) {
+	defer teardown()
+	resp, _ := http.Get(server.URL + "/auth/promote")
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 4** Method Not Allowed since /auth/promote only accepts POSTs")
+	}
+}
+
+func TestSyncList(t *testing.T) {
+	queueDomain("example.com")
+	queueDomain("eff.org")
+	resp, _ := http.PostForm(server.URL+"/auth/promote", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected promote to succeed")
+	}
+	expectDomainState(t, "eff.org", db.StateAdded)
+	expectDomainState(t, "example.com", db.StateQueued)
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func registerHandlers(api *API, mux *http.ServeMux) http.Handler {
 	mux.HandleFunc("/api/validate", apiWrapper(api.Validate))
 	mux.HandleFunc("/api/ping", pingHandler)
 	mux.HandleFunc("/auth/list", apiWrapper(api.GetList))
+	mux.HandleFunc("/auth/fail", apiWrapper(api.FailDomain))
 
 	return middleware(mux)
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func registerHandlers(api *API, mux *http.ServeMux) http.Handler {
 	mux.HandleFunc("/api/ping", pingHandler)
 	mux.HandleFunc("/auth/list", apiWrapper(api.GetList))
 	mux.HandleFunc("/auth/fail", apiWrapper(api.FailDomain))
+	mux.HandleFunc("/auth/promote", apiWrapper(api.PromoteListedDomains))
 
 	return middleware(mux)
 }


### PR DESCRIPTION
fixes #122. depends on #118. subpart of #6.

thinking to rename rename `list_api` to `auth_api`

Adds two new endpoints under `auth`: `promote` and `fail`.
`promote` auto-promotes any entries in the DB which are already on the list.
`fail` fails a specified domain.