### PR TITLE
Pin postgres dependency version

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres
+FROM postgres:10
 
 # Initialize starttls tables
 ADD scripts/init_tables.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Most recent staging deployment can't start the database: `The data directory was initialized by PostgreSQL version 10, which is not compatible with this version 11.1`