### PR TITLE
fix hostname scan caching

### DIFF
--- a/checker/cache.go
+++ b/checker/cache.go
@@ -26,7 +26,7 @@ func (c *ScanCache) GetHostnameScan(hostname string) (HostnameResult, error) {
 		return result, err
 	}
 	if time.Now().Sub(result.Timestamp) > c.ExpireTime {
-		return result, fmt.Errorf("Most recent scan for %s expired", hostname)
+		return result, fmt.Errorf("most recent scan for %s expired", hostname)
 	}
 	return result, nil
 }

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -267,17 +267,14 @@ func (db SQLDatabase) GetName() string {
 	return "SQL Database"
 }
 
-const cacheTime = time.Minute * 5
-
 // GetHostnameScan retrives most recent scan from database.
 func (db *SQLDatabase) GetHostnameScan(hostname string) (checker.HostnameResult, error) {
 	result := checker.HostnameResult{Hostname: hostname}
 	var rawScanData []byte
-	var timestamp time.Time
 	err := db.conn.QueryRow(`SELECT timestamp, status, scandata FROM hostname_scans
                     WHERE hostname=$1 AND
                     timestamp=(SELECT MAX(timestamp) FROM hostname_scans WHERE hostname=$1)`,
-		hostname).Scan(&timestamp, &result.Status, &rawScanData)
+		hostname).Scan(&result.Timestamp, &result.Status, &rawScanData)
 	if err != nil {
 		return result, err
 	}

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -304,13 +304,14 @@ func TestPutAndIsBlacklistedEmail(t *testing.T) {
 func TestGetHostnameScan(t *testing.T) {
 	checksMap := make(map[string]checker.CheckResult)
 	checksMap["test"] = checker.CheckResult{}
+	now = time.Now()
 	database.PutHostnameScan("hello", checker.HostnameResult{
-		Hostname: "hello", Status: 1, Checks: checksMap})
+		Timestamp: now, Hostname: "hello", Status: 1, Checks: checksMap})
 	result, err := database.GetHostnameScan("hello")
 	if err != nil {
 		t.Errorf("Expected hostname scan to return without errors")
 	}
-	if result.Status != 1 || checksMap["test"].Name != result.Checks["test"].Name {
+	if result.Timestamp != now || result.Status != 1 || checksMap["test"].Name != result.Checks["test"].Name {
 		t.Errorf("Expected hostname scan to return correct data")
 	}
 }

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -304,14 +304,17 @@ func TestPutAndIsBlacklistedEmail(t *testing.T) {
 func TestGetHostnameScan(t *testing.T) {
 	checksMap := make(map[string]checker.CheckResult)
 	checksMap["test"] = checker.CheckResult{}
-	now = time.Now()
+	now := time.Now()
 	database.PutHostnameScan("hello", checker.HostnameResult{
-		Timestamp: now, Hostname: "hello", Status: 1, Checks: checksMap})
+		Timestamp: time.Now(), Hostname: "hello", Status: 1, Checks: checksMap})
 	result, err := database.GetHostnameScan("hello")
 	if err != nil {
 		t.Errorf("Expected hostname scan to return without errors")
 	}
-	if result.Timestamp != now || result.Status != 1 || checksMap["test"].Name != result.Checks["test"].Name {
+	if now.Sub(result.Timestamp) > time.Second {
+		t.Errorf("unexpected gap between written timestamp %s and read timestamp %s", now, result.Timestamp)
+	}
+	if result.Status != 1 || checksMap["test"].Name != result.Checks["test"].Name {
 		t.Errorf("Expected hostname scan to return correct data")
 	}
 }


### PR DESCRIPTION
We weren't serializing the timestamp into the correct place, so the cache kept expiring.