### PR TITLE
Move strings describing checks to backend

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -1,6 +1,9 @@
 package checker
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // CheckStatus is an enum encoding the status of the overall check.
 type CheckStatus int32
@@ -74,4 +77,90 @@ func (c CheckResult) Success() CheckResult {
 	c.ensureInit()
 	c.Status = SetStatus(c.Status, Success)
 	return c
+}
+
+// MarshalJSON specifies how json.Marshall should handle type CheckResult.
+// Adds status_text and description fields to the default output.
+func (c CheckResult) MarshalJSON() ([]byte, error) {
+	// FakeCheckResult lets us access the default json.Marshall result for CheckResult.
+	type FakeCheckResult CheckResult
+	return json.Marshal(struct {
+		FakeCheckResult
+		StatusText  string `json:"status_text,omitempty"`
+		Description string `json:"description,omitempty"`
+	}{
+		FakeCheckResult: FakeCheckResult(c),
+		StatusText:      c.StatusText(),
+		Description:     c.Description(),
+	})
+}
+
+// StatusText returns a human-readable status string
+func (c CheckResult) StatusText() string {
+	if checkType, ok := checkTypes[c.Name]; ok {
+		if statusText, ok := checkType.StatusText[c.Status]; ok {
+			return statusText
+		}
+	}
+	return ""
+}
+
+// Description returns a technical description of the check that was
+// performed.
+func (c CheckResult) Description() string {
+	if checkType, ok := checkTypes[c.Name]; ok {
+		return checkType.Description
+	}
+	return ""
+}
+
+// CheckTypes stores descriptive information about the types of check that can
+// be performed by the Checker.
+type CheckTypes map[string]CheckType
+
+// CheckType stores descriptive information about a single type of check that
+// can be performed by the Checker.
+type CheckType struct {
+	StatusText
+	Description string
+}
+
+// StatusText maps CheckStatus codes to human-readable strings.
+type StatusText map[CheckStatus]string
+
+var checkTypes = CheckTypes{
+	"starttls": CheckType{
+		StatusText: StatusText{
+			Success: "Supports STTARTTLS",
+			Failure: "Does not support STARTTLS",
+		},
+		Description: `“STARTTLS” is the command an email server sends if it wants to encrypt communications (using Transport Layer Security or “TLS”) with another email server. If your server supports STARTTLS, that means any other server that supports STARTTLS can communicate securely with it.
+
+This checks that your email server sends the STARTTLS command correctly, as well as accepting the STARTTLS command from other servers.`,
+	},
+	"version": CheckType{
+		StatusText: StatusText{
+			Success: "Uses a secure version of TLS",
+			Failure: "Does not use a secure TLS version",
+		},
+		Description: `TLS has changed many times over the years. Researchers have discovered security flaws in some older versions, named “SSLv2” and “SSLv3”, so technologists across the internet are <a href="https://disablessl3.com/" target="_blank">working to deprecate</a> SSLv2/3.
+
+This checks that your email server does not allow establishing a valid TLS connection over SSLv2/3.`,
+	},
+	"certificate": CheckType{
+		StatusText: StatusText{
+			Success: "Presents a valid certificate",
+			Failure: "Does not present a valid certificate",
+		},
+		Description: `On the internet, even if you *think* you’re talking to a service named “eff.org”, it could be an impersonator pretending to be “eff.org”. Checking a mail server’s certificate helps ensure that you really are talking to the actual service.
+
+In order for your certificate to be valid for your email domain, it should be unexpired, chain to a <a href="https://wiki.mozilla.org/CA/Included_Certificates" target="_blank">valid root</a>, and one of the names on the certificate should either match the domain (the part of an email address after the @) or the server’s hostname (the name of the server, as indicated by an MX record).`,
+	},
+	"connectivity": CheckType{
+		StatusText: StatusText{
+			Success: "Server is up and running",
+			Failure: "Could not establish connection",
+		},
+		Description: `We couldn't successfully connect to this mailserver to scan it. This could be an error on our side, too. If you're having trouble getting the scanner to work, shoot us an email at <a href="mailto:starttls-policy@eff.org">starttls-policy@eff.org</a>.`,
+	},
 }

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -1,0 +1,41 @@
+package checker
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalResultJSON(t *testing.T) {
+	// Should set description and status_text for CheckResult w/ recognized keys
+	result := CheckResult{
+		Name:   "starttls",
+		Status: Success,
+	}
+	marshalled, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(marshalled, []byte("\"status_text\":\"Supports")) {
+		t.Errorf(string(marshalled))
+	}
+	if !bytes.Contains(marshalled, []byte("\"description\":\"")) {
+		t.Errorf(string(marshalled))
+	}
+
+	// Should survive unrecognized keys
+	result = CheckResult{
+		Name:   "foo",
+		Status: 100,
+	}
+	marshalled, _ = json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(marshalled, []byte("\"status_text\":\"")) {
+		t.Errorf(string(marshalled))
+	}
+	if bytes.Contains(marshalled, []byte("\"description\":\"")) {
+		t.Errorf(string(marshalled))
+	}
+}


### PR DESCRIPTION
This is the very beginning of #126.

Next step is to conditionally render either JSON or a fairly bare HTML template depending on the request headers.

Some other strings will also need to be moved to the backend as well, but I figured I'd open this to show you generally what I have in mind.

If we want more separation between code and content, we can move the contents of `checkTypes` to a yaml file and load it into the Go variable at runtime. I'd like to see what other kinds of strings we need to keep track of first.