### PR TITLE
Wildcard matching works without an asterisk label

### DIFF
--- a/checker/domain_test.go
+++ b/checker/domain_test.go
@@ -11,6 +11,7 @@ var mxLookup = map[string][]string{
 	"empty":         []string{},
 	"changes":       []string{"changes"},
 	"domain":        []string{"hostname1", "hostname2"},
+	"domain.tld":    []string{"mail2.domain.tld", "mail1.domain.tld"},
 	"noconnection":  []string{"noconnection", "noconnection"},
 	"noconnection2": []string{"noconnection", "nostarttlsconnect"},
 	"nostarttls":    []string{"nostarttls", "noconnection"},
@@ -134,6 +135,14 @@ func TestNoExpectedHostnames(t *testing.T) {
 		{"domain", []string{"hostname1"}, DomainBadHostnameFailure},
 		{"domain", []string{"hostname1", "hostname2"}, DomainSuccess},
 		{"domain", nil, DomainSuccess},
+	}
+	performTests(t, tests)
+}
+
+func TestWildcardHostnames(t *testing.T) {
+	tests := []domainTestCase{
+		{"domain.tld", []string{".tld"}, DomainBadHostnameFailure},
+		{"domain.tld", []string{".domain.tld"}, DomainSuccess},
 	}
 	performTests(t, tests)
 }

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -49,9 +49,10 @@ func policyMatches(mx string, patterns []string) bool {
 			return true
 		}
 		// Wildcard match
-		if strings.HasPrefix(pattern, "*.") {
+		if strings.HasPrefix(pattern, "*.") || strings.HasPrefix(pattern, ".") {
+			pattern = strings.TrimPrefix(pattern, "*")
 			mxParts := strings.SplitN(mx, ".", 2)
-			if len(mxParts) > 1 && mxParts[1] == pattern[2:] {
+			if len(mxParts) > 1 && mxParts[1] == pattern[1:] {
 				return true
 			}
 		}

--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -69,7 +69,9 @@ func TestPolicyMatch(t *testing.T) {
 
 		// Single-level subdomain match
 		{"mx.example.com", "*.example.com", true},
+		{"mx.example.com", ".example.com", true},
 		{"mx.mx.example.com", "*.mx.example.com", true},
+		{"mx.mx.example.com", ".mx.example.com", true},
 
 		// Wildcard may match left-most label only
 		{"mx.example.com", "mx.*.com", false},
@@ -84,6 +86,9 @@ func TestPolicyMatch(t *testing.T) {
 		{"*.example.com", "mx.example.com", false},
 		{"*.example.com", "mx.mx.example.com", false},
 		{"*.example.com", ".mx.example.com", false},
+
+		// Some more edge cases
+		{"mx.example.com", "..example.com", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
That is, patterns like ".example.com" match the same way
as "*.example.com". This is important just to match the original
policy matching rules, so we get fewer false negatives
while running list validations.