### PR TITLE
Include extra MTA-STS info in domain result

### DIFF
--- a/checker/domain.go
+++ b/checker/domain.go
@@ -46,6 +46,8 @@ type DomainResult struct {
 	PreferredHostnames []string `json:"preferred_hostnames"`
 	// Expected MX hostnames supplied by the caller of CheckDomain.
 	MxHostnames []string `json:"mx_hostnames,omitempty"`
+	// Result of MTA-STS checks
+	MTASTSResult *MTASTSResult `json:"mta_sts"`
 	// Extra global results
 	ExtraResults map[string]*Result `json:"extra_results,omitempty"`
 }
@@ -148,7 +150,7 @@ func (c *Checker) CheckDomain(domain string, expectedHostnames []string) DomainR
 		}
 		result = result.setStatus(DomainStatus(hostnameResult.Status))
 	}
-	result.ExtraResults["mta-sts"] = c.checkMTASTS(domain, result.HostnameResults)
+	result.MTASTSResult = c.checkMTASTS(domain, result.HostnameResults)
 	// result.setStatus(DomainStatus(result.ExtraResults["mta-sts"].Status))
 	return result
 }

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -18,21 +18,12 @@ type HostnameResult struct {
 	Timestamp time.Time `json:"-"`
 }
 
-// Returns result of specified check.
-// If called before that check occurs, returns false.
-func (h HostnameResult) checkSucceeded(checkName string) bool {
-	if result, ok := h.Checks[checkName]; ok {
-		return result.Status == Success
-	}
-	return false
-}
-
 func (h HostnameResult) couldConnect() bool {
-	return h.checkSucceeded(Connectivity)
+	return h.subcheckSucceeded(Connectivity)
 }
 
 func (h HostnameResult) couldSTARTTLS() bool {
-	return h.checkSucceeded(STARTTLS)
+	return h.subcheckSucceeded(STARTTLS)
 }
 
 // Modelled after policyMatches in Appendix B of the MTA-STS RFC 8641.

--- a/checker/mta_sts.go
+++ b/checker/mta_sts.go
@@ -72,7 +72,7 @@ func checkMTASTSRecord(domain string) *Result {
 	result := MakeResult(MTASTSText)
 	records, err := net.LookupTXT(fmt.Sprintf("_mta-sts.%s", domain))
 	if err != nil {
-		return result.Failure("Couldn't find MTA-STS TXT record: %v", err)
+		return result.Failure("Couldn't find an MTA-STS TXT record: %v", err)
 	}
 	return validateMTASTSRecord(records, result)
 }
@@ -80,13 +80,13 @@ func checkMTASTSRecord(domain string) *Result {
 func validateMTASTSRecord(records []string, result *Result) *Result {
 	records = filterByPrefix(records, "v=STSv1")
 	if len(records) != 1 {
-		return result.Failure("exactly 1 MTA-STS TXT record required, found %d", len(records))
+		return result.Failure("Exactly 1 MTA-STS TXT record required, found %d", len(records))
 	}
 	record := getKeyValuePairs(records[0], ";", "=")
 
 	idPattern := regexp.MustCompile("^[a-zA-Z0-9]+$")
 	if !idPattern.MatchString(record["id"]) {
-		return result.Failure("invalid id %s", record["id"])
+		return result.Failure("Invalid id %s", record["id"])
 	}
 	return result.Success()
 }

--- a/checker/mta_sts.go
+++ b/checker/mta_sts.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// HostnameResult wraps the results of a security check against a particular hostname.
+// MTASTSResult represents the result of a check for inbound MTA-STS support.
 type MTASTSResult struct {
 	*Result
 	Policy string `json:"policy"`
@@ -25,6 +25,8 @@ func MakeMTASTSResult(name string) *MTASTSResult {
 	}
 }
 
+// MarshalJSON prevents MTASTSResult from inheriting the version of MarshalJSON
+// implemented by Result.
 func (m MTASTSResult) MarshalJSON() ([]byte, error) {
 	// type FakeMTASTSResult MTASTSResult
 	type FakeResult Result

--- a/checker/mta_sts.go
+++ b/checker/mta_sts.go
@@ -14,7 +14,7 @@ import (
 // MTASTSResult represents the result of a check for inbound MTA-STS support.
 type MTASTSResult struct {
 	*Result
-	Policy string `json:"policy"`
+	Policy string `json:"policy"` // Text of MTA-STS policy file
 	Mode   string `json:"mode"`
 }
 

--- a/checker/mta_sts_test.go
+++ b/checker/mta_sts_test.go
@@ -1,9 +1,22 @@
 package checker
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 )
+
+func TestMarshalMTASTSJSON(t *testing.T) {
+	r := MakeMTASTSResult(MTASTS)
+	_, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(marshalled, []byte("\"policy\":\"")) {
+		t.Errorf("Marshalled result should contain policy, got %s", string(marshalled))
+	}
+}
 
 func TestGetKeyValuePairs(t *testing.T) {
 	tests := []struct {
@@ -67,7 +80,8 @@ func TestValidateMTASTSPolicyFile(t *testing.T) {
 		{"version: STSv1\nmode: start_turtles\nmax_age:100000\nmx: foo.example.com\nmx: bar.example.com\n", Failure},
 	}
 	for _, test := range tests {
-		result, _ := validateMTASTSPolicyFile(test.txt, &Result{})
+		result := &Result{}
+		validateMTASTSPolicyFile(test.txt, result)
 		if result.Status != test.status {
 			t.Errorf("validateMTASTSPolicyFile(%v) = %v", test.txt, result)
 		}
@@ -125,7 +139,8 @@ func TestValidateMTASTSMXs(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		result := validateMTASTSMXs(test.policyFileMXs, test.dnsMXs, &Result{})
+		result := &Result{}
+		validateMTASTSMXs(test.policyFileMXs, test.dnsMXs, result)
 		if result.Status != test.status {
 			t.Errorf("validateMTASTSMXs(%v, %v, %v) = %v", test.policyFileMXs, test.dnsMXs, Result{}, result)
 		}

--- a/checker/mta_sts_test.go
+++ b/checker/mta_sts_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestMarshalMTASTSJSON(t *testing.T) {
 	r := MakeMTASTSResult(MTASTS)
-	_, err := json.Marshal(r)
+	m, err := json.Marshal(r)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(marshalled, []byte("\"policy\":\"")) {
-		t.Errorf("Marshalled result should contain policy, got %s", string(marshalled))
+	if !bytes.Contains(m, []byte("\"policy\":\"")) {
+		t.Errorf("Marshalled result should contain policy, got %s", string(m))
 	}
 }
 

--- a/checker/result.go
+++ b/checker/result.go
@@ -146,8 +146,8 @@ func (r Result) MarshalJSON() ([]byte, error) {
 		StatusText  string `json:"status_text,omitempty"`
 		Description string `json:"description,omitempty"`
 	}{
+		Description: r.Description(),
 		FakeResult:  FakeResult(r),
 		StatusText:  r.StatusText(),
-		Description: r.Description(),
 	})
 }


### PR DESCRIPTION
Include MTA-STS policy and mode and domain result so we can render that info.

I realized a weird thing about implementing `MarshalJSON` for `Result` - since `Result` is embedded in `MTASTSResult` (and `HostnameResult`), those types also use `Result`'s overridden `MarshalJSON` and lose their additional fields :upside_down_face:. I fixed that by implementing it directly on `MTASTSResult` as well. I think that extra strings that get added to the `Result` JSON are useful for debugging (I always forget the status mappings when I'm working on the frontend) but I'd also be fine with simplifying things by getting rid of them now that we're keeping the longer strings in Hugo.