### PR TITLE
Queueability to model

### DIFF
--- a/api.go
+++ b/api.go
@@ -51,7 +51,7 @@ type API struct {
 // The most important query you can perform is to fetch the policy
 // for a particular domain.
 type PolicyList interface {
-	Get(string) (policy.TLSPolicy, error)
+	HasDomain(string) bool
 	Raw() policy.List
 }
 
@@ -90,7 +90,7 @@ func apiWrapper(api apiHandler) func(w http.ResponseWriter, r *http.Request) {
 // Checks the policy status of this domain.
 func (api API) policyCheck(domain string) *checker.Result {
 	result := checker.Result{Name: checker.PolicyList}
-	if _, err := api.List.Get(domain); err == nil {
+	if api.List.HasDomain(domain) {
 		return result.Success()
 	}
 	domainData, err := api.Database.GetDomain(domain)

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -49,11 +48,9 @@ func (l mockList) Raw() policy.List {
 	return list
 }
 
-func (l mockList) Get(domain string) (policy.TLSPolicy, error) {
-	if _, ok := l.domains[domain]; ok {
-		return policy.TLSPolicy{Mode: "enforce", MXs: []string{"mx.fake.com"}}, nil
-	}
-	return policy.TLSPolicy{}, fmt.Errorf("no such domain on this list")
+func (l mockList) HasDomain(domain string) bool {
+	_, ok := l.domains[domain]
+	return ok
 }
 
 // Mock emailer

--- a/models/domain.go
+++ b/models/domain.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/EFForg/starttls-backend/policy"
+)
 
 // Domain stores the preload state of a single domain.
 type Domain struct {
@@ -22,3 +26,30 @@ const (
 	StateFailed      = "failed"      // Requested to be queued, but failed verification.
 	StateAdded       = "added"       // On the list.
 )
+
+type policyList interface {
+	Get(string) (policy.TLSPolicy, error)
+	// HasDomain(string) bool
+}
+
+type scanStore interface {
+	GetLatestScan(string) (Scan, error)
+}
+
+func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string) {
+	// Check if successful scan occurred.
+	scan, err := db.GetLatestScan(d.Name)
+	if err != nil {
+		return false, "We haven't scanned this domain yet. " +
+			"Please use the STARTTLS checker to scan your domain's " +
+			"STARTTLS configuration so we can validate your submission"
+	}
+	if scan.Data.Status != 0 {
+		return false, "Domain hasn't passed our STARTTLS security checks"
+	}
+	// Check to see it's not already on the Policy List.
+	if _, err := list.Get(d.Name); err == nil {
+		return false, "Domain is already on the policy list!"
+	}
+	return true, ""
+}

--- a/models/domain.go
+++ b/models/domain.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"time"
-
-	"github.com/EFForg/starttls-backend/policy"
 )
 
 // Domain stores the preload state of a single domain.
@@ -28,8 +26,7 @@ const (
 )
 
 type policyList interface {
-	Get(string) (policy.TLSPolicy, error)
-	// HasDomain(string) bool
+	HasDomain(string) bool
 }
 
 type scanStore interface {
@@ -48,7 +45,7 @@ func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string) {
 		return false, "Domain hasn't passed our STARTTLS security checks"
 	}
 	// Check to see it's not already on the Policy List.
-	if _, err := list.Get(d.Name); err == nil {
+	if list.HasDomain(d.Name) {
 		return false, "Domain is already on the policy list!"
 	}
 	return true, ""

--- a/models/domain.go
+++ b/models/domain.go
@@ -33,6 +33,8 @@ type scanStore interface {
 	GetLatestScan(string) (Scan, error)
 }
 
+// IsQueueable returns true if a domain can be submitted for validation and
+// queueing to the STARTTLS Everywhere Policy List.
 func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string) {
 	// Check if successful scan occurred.
 	scan, err := db.GetLatestScan(d.Name)

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/EFForg/starttls-backend/checker"
+)
+
+type mockList struct {
+	hasDomain bool
+}
+
+func (m mockList) HasDomain(string) bool { return m.hasDomain }
+
+type mockScanStore struct {
+	scan Scan
+	err  error
+}
+
+func (m mockScanStore) GetLatestScan(string) (Scan, error) { return m.scan, m.err }
+
+func TestIsQueueable(t *testing.T) {
+	d := Domain{
+		Name:  "example.com",
+		Email: "me@example.com",
+		MXs:   []string{"mx1.example.com", "mx2.example.com"},
+	}
+	ok, msg := d.IsQueueable(mockScanStore{Scan{}, nil}, mockList{false})
+	if !ok {
+		t.Error("Unadded domain with passing scan should be queueable")
+	}
+	ok, msg = d.IsQueueable(mockScanStore{Scan{}, nil}, mockList{true})
+	if ok || !strings.Contains(msg, "already on the policy list") {
+		t.Error("Domain on policy list should not be queueable")
+	}
+	failed_scan := Scan{
+		Data: checker.DomainResult{Status: checker.DomainFailure},
+	}
+	ok, msg = d.IsQueueable(mockScanStore{failed_scan, nil}, mockList{false})
+	if ok || !strings.Contains(msg, "hasn't passed") {
+		t.Error("Domain with failing scan should not be queueable")
+	}
+	ok, msg = d.IsQueueable(mockScanStore{Scan{}, errors.New("")}, mockList{false})
+	if ok || !strings.Contains(msg, "haven't scanned") {
+		t.Error("Domain without scan should not be queueable")
+	}
+}

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -35,10 +35,10 @@ func TestIsQueueable(t *testing.T) {
 	if ok || !strings.Contains(msg, "already on the policy list") {
 		t.Error("Domain on policy list should not be queueable")
 	}
-	failed_scan := Scan{
+	failedScan := Scan{
 		Data: checker.DomainResult{Status: checker.DomainFailure},
 	}
-	ok, msg = d.IsQueueable(mockScanStore{failed_scan, nil}, mockList{false})
+	ok, msg = d.IsQueueable(mockScanStore{failedScan, nil}, mockList{false})
 	if ok || !strings.Contains(msg, "hasn't passed") {
 		t.Error("Domain with failing scan should not be queueable")
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -102,7 +102,7 @@ func (l *UpdatedList) Get(domain string) (TLSPolicy, error) {
 	return l.get(domain)
 }
 
-// Get safely reads from the underlying policy list and returns a TLSPolicy for a domain
+// HasDomain returns true if a domain is present on the policy list.
 func (l *UpdatedList) HasDomain(domain string) bool {
 	_, err := l.Get(domain)
 	return err != nil

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -102,6 +102,12 @@ func (l *UpdatedList) Get(domain string) (TLSPolicy, error) {
 	return l.get(domain)
 }
 
+// Get safely reads from the underlying policy list and returns a TLSPolicy for a domain
+func (l *UpdatedList) HasDomain(domain string) bool {
+	_, err := l.Get(domain)
+	return err != nil
+}
+
 // Raw returns a raw List struct, copied from the underlying one
 func (l *UpdatedList) Raw() List {
 	l.mu.RLock()


### PR DESCRIPTION
Now that we have models, moving some queue logic out of the handler. I also added some helpers for common `APIResponse` status codes to make the handler a bit easier to scan.

This is preparation for checking hostnames or MTA-STS success in #146. 