### PR TITLE
Accept MTA-STS boolean or check hostnames match

### DIFF
--- a/api.go
+++ b/api.go
@@ -220,20 +220,22 @@ func getDomainParams(r *http.Request) (models.Domain, error) {
 		domain.Email = validationAddress(&domain)
 	}
 
-	for _, hostname := range r.PostForm["hostnames"] {
-		if len(hostname) == 0 {
-			continue
+	if mtasts != "on" {
+		for _, hostname := range r.PostForm["hostnames"] {
+			if len(hostname) == 0 {
+				continue
+			}
+			if !validDomainName(strings.TrimPrefix(hostname, ".")) {
+				return domain, fmt.Errorf("Hostname %s is invalid", hostname)
+			}
+			domain.MXs = append(domain.MXs, hostname)
 		}
-		if !validDomainName(strings.TrimPrefix(hostname, ".")) {
-			return domain, fmt.Errorf("hostname %s is invalid", hostname)
+		if len(domain.MXs) == 0 {
+			return domain, fmt.Errorf("No MX hostnames supplied for domain %s", domain.Name)
 		}
-		domain.MXs = append(domain.MXs, hostname)
-	}
-	if len(domain.MXs) == 0 {
-		return domain, fmt.Errorf("no MX hostnames supplied for domain %s", domain.Name)
-	}
-	if len(domain.MXs) > MaxHostnames {
-		return domain, fmt.Errorf("no more than 8 MX hostnames are permitted")
+		if len(domain.MXs) > MaxHostnames {
+			return domain, fmt.Errorf("No more than 8 MX hostnames are permitted")
+		}
 	}
 	return domain, nil
 }

--- a/api.go
+++ b/api.go
@@ -207,7 +207,12 @@ func getDomainParams(r *http.Request) (models.Domain, error) {
 	if err != nil {
 		return models.Domain{}, err
 	}
-	domain := models.Domain{Name: name, State: models.StateUnvalidated}
+	mtasts := r.FormValue("mta-sts")
+	domain := models.Domain{
+		Name:       name,
+		MTASTSMode: mtasts,
+		State:      models.StateUnvalidated,
+	}
 	email, err := getParam("email", r)
 	if err == nil {
 		domain.Email = email
@@ -236,7 +241,7 @@ func getDomainParams(r *http.Request) (models.Domain, error) {
 // Queue is the handler for /api/queue
 //   POST /api/queue?domain=<domain>
 //        domain: Mail domain to queue a TLS policy for.
-//				mta_sts: True if domain supports MTA-STS else false.
+//				mta_sts: "on" if domain supports MTA-STS, else "".
 //        hostnames: List of MX hostnames to put into this domain's TLS policy. Up to 8.
 //        Sets models.Domain object as response.
 //        email (optional): Contact email associated with domain.

--- a/api.go
+++ b/api.go
@@ -255,9 +255,11 @@ func (api API) Queue(r *http.Request) APIResponse {
 			return badRequest(err.Error())
 		}
 		// 0. Verify that we can queue the domain.
-		if ok, msg := domain.IsQueueable(api.Database, api.List); !ok {
+		ok, msg, scan := domain.IsQueueable(api.Database, api.List)
+		if !ok {
 			return badRequest(msg)
 		}
+		domain.PopulateFromScan(scan)
 		// 1. Insert domain into DB
 		if err = api.Database.PutDomain(domain); err != nil {
 			return serverError(err.Error())

--- a/api.go
+++ b/api.go
@@ -253,12 +253,6 @@ func (api API) Queue(r *http.Request) APIResponse {
 		if ok, msg := domain.IsQueueable(api.Database, api.List); !ok {
 			return badRequest(msg)
 		}
-		// 0. Check that hostnames match.
-		// if mta_sts && scan.Data.MTASTS.Status != Success {
-		// 	return badRequest("%d does not correctly implement MTA-STS.", domain)
-		// } else if !scan.matchesHostnames(hostnames) {
-		// 	return badRequest("%d is not valid for the supplied hostnames.", domain)
-		// }
 		// 1. Insert domain into DB
 		if err = api.Database.PutDomain(domain); err != nil {
 			return serverError(err.Error())

--- a/api.go
+++ b/api.go
@@ -253,6 +253,12 @@ func (api API) Queue(r *http.Request) APIResponse {
 		if ok, msg := domain.IsQueueable(api.Database, api.List); !ok {
 			return badRequest(msg)
 		}
+		// 0. Check that hostnames match.
+		// if mta_sts && scan.Data.MTASTS.Status != Success {
+		// 	return badRequest("%d does not correctly implement MTA-STS.", domain)
+		// } else if !scan.matchesHostnames(hostnames) {
+		// 	return badRequest("%d is not valid for the supplied hostnames.", domain)
+		// }
 		// 1. Insert domain into DB
 		if err = api.Database.PutDomain(domain); err != nil {
 			return serverError(err.Error())

--- a/checker/domain.go
+++ b/checker/domain.go
@@ -145,7 +145,7 @@ func (c *Checker) CheckDomain(domain string, expectedHostnames []string) DomainR
 			return result.setStatus(DomainNoSTARTTLSFailure)
 		}
 		// Any of the connected hostnames don't have a match?
-		if expectedHostnames != nil && !policyMatches(hostname, expectedHostnames) {
+		if expectedHostnames != nil && !PolicyMatches(hostname, expectedHostnames) {
 			return result.setStatus(DomainBadHostnameFailure)
 		}
 		result = result.setStatus(DomainStatus(hostnameResult.Status))

--- a/checker/domain.go
+++ b/checker/domain.go
@@ -185,6 +185,8 @@ func NewSampleDomainResult(domain string) DomainResult {
 					MTASTSPolicyFile: MakeResult(MTASTSPolicyFile),
 				},
 			},
+			Mode: "enforce",
+			MXs:  []string{"." + domain},
 		},
 		ExtraResults: map[string]*Result{
 			PolicyList: MakeResult(PolicyList),

--- a/checker/domain.go
+++ b/checker/domain.go
@@ -154,3 +154,40 @@ func (c *Checker) CheckDomain(domain string, expectedHostnames []string) DomainR
 	// result.setStatus(DomainStatus(result.ExtraResults["mta-sts"].Status))
 	return result
 }
+
+// NewSampleDomainResult returns a sample successful domain result for testing.
+// This is exported so other packages can use it in their integration tests.
+func NewSampleDomainResult(domain string) DomainResult {
+	hostname := "mx." + domain
+	return DomainResult{
+		Domain: domain,
+		Status: DomainSuccess,
+		HostnameResults: map[string]HostnameResult{
+			hostname: HostnameResult{
+				Domain:   domain,
+				Hostname: hostname,
+				Result: &Result{
+					Checks: map[string]*Result{
+						Connectivity: MakeResult(Connectivity),
+						STARTTLS:     MakeResult(STARTTLS),
+						Certificate:  MakeResult(Certificate),
+						Version:      MakeResult(Version),
+					},
+				},
+			},
+		},
+		PreferredHostnames: []string{hostname},
+		MTASTSResult: &MTASTSResult{
+			Result: &Result{
+				Status: Success,
+				Checks: map[string]*Result{
+					MTASTSText:       MakeResult(MTASTSText),
+					MTASTSPolicyFile: MakeResult(MTASTSPolicyFile),
+				},
+			},
+		},
+		ExtraResults: map[string]*Result{
+			PolicyList: MakeResult(PolicyList),
+		},
+	}
+}

--- a/checker/domain_test.go
+++ b/checker/domain_test.go
@@ -185,3 +185,7 @@ func TestHostnameScanExpires(t *testing.T) {
 		{domain: "changes", expect: 4}}
 	performTestsWithCacheTimeout(t, tests, 0)
 }
+
+func TestNewSampleDomainResult(t *testing.T) {
+	NewSampleDomainResult("example.com")
+}

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -26,9 +26,10 @@ func (h HostnameResult) couldSTARTTLS() bool {
 	return h.subcheckSucceeded(STARTTLS)
 }
 
-// Modelled after policyMatches in Appendix B of the MTA-STS RFC 8641.
+// PolicyMatches return true iff a given mx matches an array of patterns.
+// It is modelled after PolicyMatches in Appendix B of the MTA-STS RFC 8641.
 // Also used to validate hostnames on the STARTTLS Everywhere policy list.
-func policyMatches(mx string, patterns []string) bool {
+func PolicyMatches(mx string, patterns []string) bool {
 	mx = strings.TrimSuffix(mx, ".") // If FQDN, might end with .
 	mx = withoutPort(mx)             // If URL, might include port
 	mx = strings.ToLower(mx)         // Lowercase for comparison

--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -95,7 +95,7 @@ func TestPolicyMatch(t *testing.T) {
 
 	for _, test := range tests {
 		policy := []string{test.policyMX}
-		if got := policyMatches(test.hostname, policy); got != test.want {
+		if got := PolicyMatches(test.hostname, policy); got != test.want {
 			t.Errorf("policyMatch(%q, %q) = %v", test.hostname, policy, got)
 		}
 	}

--- a/checker/mta_sts.go
+++ b/checker/mta_sts.go
@@ -159,7 +159,7 @@ func validateMTASTSMXs(policyFileMXs []string, dnsMXs map[string]HostnameResult,
 			// Ignore hostnames we couldn't connect to, they may be spam traps.
 			continue
 		}
-		if !policyMatches(dnsMX, policyFileMXs) {
+		if !PolicyMatches(dnsMX, policyFileMXs) {
 			result.Warning("%s appears in the DNS record but not the MTA-STS policy file",
 				dnsMX)
 		} else if !dnsMXResult.couldSTARTTLS() {

--- a/checker/mta_sts.go
+++ b/checker/mta_sts.go
@@ -14,8 +14,9 @@ import (
 // MTASTSResult represents the result of a check for inbound MTA-STS support.
 type MTASTSResult struct {
 	*Result
-	Policy string `json:"policy"` // Text of MTA-STS policy file
-	Mode   string `json:"mode"`
+	Policy string // Text of MTA-STS policy file
+	Mode   string
+	MXs    []string
 }
 
 // MakeMTASTSResult constructs a base result object and returns its pointer.
@@ -32,12 +33,14 @@ func (m MTASTSResult) MarshalJSON() ([]byte, error) {
 	type FakeResult Result
 	return json.Marshal(struct {
 		FakeResult
-		Policy string `json:"policy"`
-		Mode   string `json:"mode"`
+		Policy string   `json:"policy"`
+		Mode   string   `json:"mode"`
+		MXs    []string `json:"mxs"`
 	}{
 		FakeResult: FakeResult(*m.Result),
 		Policy:     m.Policy,
 		Mode:       m.Mode,
+		MXs:        m.MXs,
 	})
 }
 
@@ -93,7 +96,7 @@ func validateMTASTSRecord(records []string, result *Result) *Result {
 	return result.Success()
 }
 
-func checkMTASTSPolicyFile(domain string, hostnameResults map[string]HostnameResult) (*Result, string, string) {
+func checkMTASTSPolicyFile(domain string, hostnameResults map[string]HostnameResult) (*Result, string, map[string]string) {
 	result := MakeResult(MTASTSPolicyFile)
 	client := &http.Client{
 		// Don't follow redirects.
@@ -104,28 +107,28 @@ func checkMTASTSPolicyFile(domain string, hostnameResults map[string]HostnameRes
 	policyURL := fmt.Sprintf("https://mta-sts.%s/.well-known/mta-sts.txt", domain)
 	resp, err := client.Get(policyURL)
 	if err != nil {
-		return result.Failure("Couldn't find policy file at %s", policyURL), "", ""
+		return result.Failure("Couldn't find policy file at %s", policyURL), "", map[string]string{}
 	}
 	if resp.StatusCode != 200 {
-		return result.Failure("Couldn't get policy file: %s returned %s", policyURL, resp.Status), "", ""
+		return result.Failure("Couldn't get policy file: %s returned %s", policyURL, resp.Status), "", map[string]string{}
 	}
 	// Media type should be text/plain, ignoring other Content-Type parms.
 	// Format: Content-Type := type "/" subtype *[";" parameter]
 	for _, contentType := range resp.Header["Content-Type"] {
 		contentType := strings.ToLower(contentType)
 		if strings.HasPrefix(contentType, "text/plain") {
-			return result.Warning("Media type must be text/plain"), "", ""
+			return result.Warning("Media type must be text/plain"), "", map[string]string{}
 		}
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return result.Error("Couldn't read policy file: %v", err), "", ""
+		return result.Error("Couldn't read policy file: %v", err), "", map[string]string{}
 	}
 
 	policy := validateMTASTSPolicyFile(string(body), result)
 	validateMTASTSMXs(strings.Split(policy["mx"], " "), hostnameResults, result)
-	return result, string(body), policy["mode"]
+	return result, string(body), policy
 }
 
 func validateMTASTSPolicyFile(body string, result *Result) map[string]string {
@@ -172,9 +175,10 @@ func validateMTASTSMXs(policyFileMXs []string, dnsMXs map[string]HostnameResult,
 func (c Checker) checkMTASTS(domain string, hostnameResults map[string]HostnameResult) *MTASTSResult {
 	result := MakeMTASTSResult()
 	result.addCheck(checkMTASTSRecord(domain))
-	policyResult, policy, mode := checkMTASTSPolicyFile(domain, hostnameResults)
+	policyResult, policy, policyMap := checkMTASTSPolicyFile(domain, hostnameResults)
 	result.addCheck(policyResult)
 	result.Policy = policy
-	result.Mode = mode
+	result.Mode = policyMap["mode"]
+	result.MXs = strings.Split(policyMap["mx"], " ")
 	return result
 }

--- a/checker/mta_sts.go
+++ b/checker/mta_sts.go
@@ -19,9 +19,9 @@ type MTASTSResult struct {
 }
 
 // MakeMTASTSResult constructs a base result object and returns its pointer.
-func MakeMTASTSResult(name string) *MTASTSResult {
+func MakeMTASTSResult() *MTASTSResult {
 	return &MTASTSResult{
-		Result: MakeResult(name),
+		Result: MakeResult(MTASTS),
 	}
 }
 
@@ -170,7 +170,7 @@ func validateMTASTSMXs(policyFileMXs []string, dnsMXs map[string]HostnameResult,
 }
 
 func (c Checker) checkMTASTS(domain string, hostnameResults map[string]HostnameResult) *MTASTSResult {
-	result := MakeMTASTSResult(MTASTS)
+	result := MakeMTASTSResult()
 	result.addCheck(checkMTASTSRecord(domain))
 	policyResult, policy, mode := checkMTASTSPolicyFile(domain, hostnameResults)
 	result.addCheck(policyResult)

--- a/checker/mta_sts_test.go
+++ b/checker/mta_sts_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMarshalMTASTSJSON(t *testing.T) {
-	r := MakeMTASTSResult(MTASTS)
+	r := MakeMTASTSResult()
 	m, err := json.Marshal(r)
 	if err != nil {
 		t.Fatal(err)

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ var server *httptest.Server
 
 func mockCheckPerform(message string) func(API, string) (checker.DomainResult, error) {
 	return func(api API, domain string) (checker.DomainResult, error) {
-		return checker.DomainResult{Domain: domain, Message: message}, nil
+		return checker.NewSampleDomainResult(domain), nil
 	}
 }
 

--- a/models/domain.go
+++ b/models/domain.go
@@ -36,25 +36,39 @@ type scanStore interface {
 
 // IsQueueable returns true if a domain can be submitted for validation and
 // queueing to the STARTTLS Everywhere Policy List.
-func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string) {
+func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string, Scan) {
 	scan, err := db.GetLatestScan(d.Name)
 	if err != nil {
 		return false, "We haven't scanned this domain yet. " +
 			"Please use the STARTTLS checker to scan your domain's " +
-			"STARTTLS configuration so we can validate your submission"
+			"STARTTLS configuration so we can validate your submission", scan
 	}
 	if scan.Data.Status != 0 {
-		return false, "Domain hasn't passed our STARTTLS security checks"
+		return false, "Domain hasn't passed our STARTTLS security checks", scan
 	}
 	if list.HasDomain(d.Name) {
-		return false, "Domain is already on the policy list!"
+		return false, "Domain is already on the policy list!", scan
 	}
 	if d.MTASTSMode != "" && !scan.SupportsMTASTS() {
-		return false, "Domain does not correctly implement MTA-STS."
+		return false, "Domain does not correctly implement MTA-STS.", scan
 	} else if !subset(d.MXs, scan.Data.PreferredHostnames) {
-		return false, "Domain is not valid for the supplied hostnames."
+		return false, "Domain is not valid for the supplied hostnames.", scan
 	}
-	return true, ""
+	return true, "", scan
+}
+
+// PopulateFromScan updates a Domain's fields based on a scan of that domain.
+func (d *Domain) PopulateFromScan(scan Scan) {
+	// We should only trust MTA-STS info from a successful MTA-STS check.
+	if scan.Data.MTASTSResult != nil && scan.SupportsMTASTS() {
+		d.MTASTSMode = scan.Data.MTASTSResult.Mode
+		// If the domain's MXs are missing, we can take them from the scan's
+		// PreferredHostnames, which must be a subset of those listed in the
+		// MTA-STS policy file.
+		if len(d.MXs) == 0 {
+			d.MXs = scan.Data.PreferredHostnames
+		}
+	}
 }
 
 func subset(small []string, big []string) bool {

--- a/models/domain.go
+++ b/models/domain.go
@@ -2,8 +2,6 @@ package models
 
 import (
 	"time"
-
-	"github.com/EFForg/starttls-backend/checker"
 )
 
 // Domain stores the preload state of a single domain.
@@ -51,7 +49,7 @@ func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string) {
 	if list.HasDomain(d.Name) {
 		return false, "Domain is already on the policy list!"
 	}
-	if d.MTASTSMode != "" && scan.Data.ExtraResults[checker.MTASTS].Status != checker.Success {
+	if d.MTASTSMode != "" && !scan.SupportsMTASTS() {
 		return false, "Domain does not correctly implement MTA-STS."
 	} else if !subset(d.MXs, scan.Data.PreferredHostnames) {
 		return false, "Domain is not valid for the supplied hostnames."

--- a/models/domain.go
+++ b/models/domain.go
@@ -35,7 +35,10 @@ type scanStore interface {
 }
 
 // IsQueueable returns true if a domain can be submitted for validation and
-// queueing to the STARTTLS Everywhere Policy List.
+ // queueing to the STARTTLS Everywhere Policy List.
+ // A successful scan should already have been submitted for this domain,
+ // and it should not already be on the policy list.
+ // Returns (queuability, error message, and most recent scan)
 func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string, Scan) {
 	scan, err := db.GetLatestScan(d.Name)
 	if err != nil {

--- a/models/domain.go
+++ b/models/domain.go
@@ -55,6 +55,7 @@ func (d *Domain) IsQueueable(db scanStore, list policyList) (bool, string, Scan)
 	if list.HasDomain(d.Name) {
 		return false, "Domain is already on the policy list!", scan
 	}
+	// Domains without submitted MTA-STS support must match provided mx patterns.
 	if d.MTASTSMode == "" {
 		for _, hostname := range scan.Data.PreferredHostnames {
 			if !checker.PolicyMatches(hostname, d.MXs) {
@@ -76,7 +77,7 @@ func (d *Domain) PopulateFromScan(scan Scan) {
 		// PreferredHostnames, which must be a subset of those listed in the
 		// MTA-STS policy file.
 		if len(d.MXs) == 0 {
-			d.MXs = scan.Data.PreferredHostnames
+			d.MXs = scan.Data.MTASTSResult.MXs
 		}
 	}
 }

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -107,16 +107,16 @@ func TestPopulateFromScan(t *testing.T) {
 	}
 	s := Scan{
 		Data: checker.DomainResult{
-			PreferredHostnames: []string{"mx1.example.com", "mx2.example.com"},
-			MTASTSResult:       checker.MakeMTASTSResult(),
+			MTASTSResult: checker.MakeMTASTSResult(),
 		},
 	}
 	s.Data.MTASTSResult.Mode = "enforce"
+	s.Data.MTASTSResult.MXs = []string{"mx1.example.com", "mx2.example.com"}
 	d.PopulateFromScan(s)
 	if d.MTASTSMode != "enforce" {
 		t.Errorf("Expected domain MTA-STS mode to match scan, got %s", d.MTASTSMode)
 	}
-	for i, mx := range s.Data.PreferredHostnames {
+	for i, mx := range s.Data.MTASTSResult.MXs {
 		if mx != d.MXs[i] {
 			t.Errorf("Expected MXs to match scan, got %s", d.MXs)
 		}

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -26,7 +26,7 @@ func TestIsQueueable(t *testing.T) {
 	d := Domain{
 		Name:  "example.com",
 		Email: "me@example.com",
-		MXs:   []string{"mx1.example.com", "mx2.example.com"},
+		MXs:   []string{".example.com"},
 	}
 	goodScan := Scan{
 		Data: checker.DomainResult{
@@ -39,7 +39,7 @@ func TestIsQueueable(t *testing.T) {
 	}
 	wrongMXsScan := Scan{
 		Data: checker.DomainResult{
-			PreferredHostnames: []string{"mx1.example.com"},
+			PreferredHostnames: []string{"mx1.nomatch.example.com"},
 		},
 	}
 	var testCases = []struct {
@@ -64,7 +64,7 @@ func TestIsQueueable(t *testing.T) {
 			ok: false, msg: "haven't scanned"},
 		{name: "Domain with mismatched hostnames should not be queueable",
 			scan: wrongMXsScan, scanErr: nil, onList: false,
-			ok: false, msg: "supplied hostnames"},
+			ok: false, msg: "do not match policy"},
 	}
 	for _, tc := range testCases {
 		ok, msg, _ := d.IsQueueable(mockScanStore{tc.scan, tc.scanErr}, mockList{tc.onList})

--- a/models/domain_test.go
+++ b/models/domain_test.go
@@ -22,28 +22,67 @@ type mockScanStore struct {
 func (m mockScanStore) GetLatestScan(string) (Scan, error) { return m.scan, m.err }
 
 func TestIsQueueable(t *testing.T) {
+	// With supplied hostnames
 	d := Domain{
 		Name:  "example.com",
 		Email: "me@example.com",
 		MXs:   []string{"mx1.example.com", "mx2.example.com"},
 	}
-	ok, msg := d.IsQueueable(mockScanStore{Scan{}, nil}, mockList{false})
-	if !ok {
-		t.Error("Unadded domain with passing scan should be queueable")
+	goodScan := Scan{
+		Data: checker.DomainResult{
+			PreferredHostnames: []string{"mx1.example.com", "mx2.example.com"},
+			MTASTSResult:       checker.MakeMTASTSResult(),
+		},
 	}
-	ok, msg = d.IsQueueable(mockScanStore{Scan{}, nil}, mockList{true})
+	ok, msg := d.IsQueueable(mockScanStore{goodScan, nil}, mockList{false})
+	if !ok {
+		t.Error("Unadded domain with passing scan should be queueable, got " + msg)
+	}
+	ok, msg = d.IsQueueable(mockScanStore{goodScan, nil}, mockList{true})
 	if ok || !strings.Contains(msg, "already on the policy list") {
-		t.Error("Domain on policy list should not be queueable")
+		t.Error("Domain on policy list should not be queueable, got " + msg)
 	}
 	failedScan := Scan{
 		Data: checker.DomainResult{Status: checker.DomainFailure},
 	}
 	ok, msg = d.IsQueueable(mockScanStore{failedScan, nil}, mockList{false})
 	if ok || !strings.Contains(msg, "hasn't passed") {
-		t.Error("Domain with failing scan should not be queueable")
+		t.Error("Domain with failing scan should not be queueable, got " + msg)
 	}
 	ok, msg = d.IsQueueable(mockScanStore{Scan{}, errors.New("")}, mockList{false})
 	if ok || !strings.Contains(msg, "haven't scanned") {
-		t.Error("Domain without scan should not be queueable")
+		t.Error("Domain without scan should not be queueable, got " + msg)
+	}
+	wrongMXsScan := Scan{
+		Data: checker.DomainResult{
+			PreferredHostnames: []string{"mx1.example.com"},
+		},
+	}
+	ok, msg = d.IsQueueable(mockScanStore{wrongMXsScan, nil}, mockList{false})
+	if ok || !strings.Contains(msg, "supplied hostnames") {
+		t.Error("Domain with mismatched hostnames should not be queueable, got " + msg)
+	}
+	// With MTA-STS
+	d = Domain{
+		Name:       "example.com",
+		Email:      "me@example.com",
+		MTASTSMode: "on",
+	}
+	ok, msg = d.IsQueueable(mockScanStore{goodScan, nil}, mockList{false})
+	if !ok {
+		t.Error("Unadded domain with passing scan should be queueable, got " + msg)
+	}
+	noMTASTSScan := Scan{
+		Data: checker.DomainResult{
+			MTASTSResult: &checker.MTASTSResult{
+				Result: &checker.Result{
+					Status: checker.Failure,
+				},
+			},
+		},
+	}
+	ok, msg = d.IsQueueable(mockScanStore{noMTASTSScan, nil}, mockList{false})
+	if ok || !strings.Contains(msg, "MTA-STS") {
+		t.Error("Domain without MTA-STS or hostnames should not be queueable, got " + msg)
 	}
 }

--- a/models/scan.go
+++ b/models/scan.go
@@ -26,3 +26,11 @@ func (s Scan) CanAddToPolicyList() bool {
 	}
 	return false
 }
+
+// SupportsMTASTS returns true if the Scan's MTA-STS check passed.
+func (s Scan) SupportsMTASTS() bool {
+	if s.Data.MTASTSResult == nil {
+		return false
+	}
+	return s.Data.MTASTSResult.Status == checker.Success
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -19,7 +19,6 @@ func validQueueData(scan bool) url.Values {
 		http.PostForm(server.URL+"/api/scan", data)
 	}
 	data.Set("email", "testing@fake-email.org")
-	data.Add("hostnames", ".example.com")
 	data.Add("hostnames", "mx.example.com")
 	return data
 }
@@ -110,8 +109,8 @@ func TestBasicQueueWorkflow(t *testing.T) {
 	if domain.State != "unvalidated" {
 		t.Fatalf("Initial state for domains should be 'unvalidated'")
 	}
-	if len(domain.MXs) != 2 {
-		t.Fatalf("Domain should have loaded two hostnames into policy")
+	if len(domain.MXs) != 1 {
+		t.Fatalf("Domain should have loaded one hostname into policy")
 	}
 
 	// 3. Validate domain token

--- a/scan_test.go
+++ b/scan_test.go
@@ -31,29 +31,8 @@ func TestScanHTMLRequest(t *testing.T) {
 
 func TestScanWriteHTML(t *testing.T) {
 	scan := models.Scan{
-		Domain: "example.com",
-		Data: checker.DomainResult{
-			Domain: "example.com",
-			Status: checker.DomainSuccess,
-			HostnameResults: map[string]checker.HostnameResult{
-				"example.com": checker.HostnameResult{
-					Domain:   "example.com",
-					Hostname: "mx.example.com",
-					Result: &checker.Result{
-						Checks: map[string]*checker.Result{
-							checker.Connectivity: checker.MakeResult(checker.Connectivity),
-							checker.STARTTLS:     checker.MakeResult(checker.STARTTLS),
-							checker.Certificate:  checker.MakeResult(checker.Certificate),
-							checker.Version:      checker.MakeResult(checker.Version),
-						},
-					},
-				},
-			},
-			PreferredHostnames: []string{"mx.example.com"},
-			ExtraResults: map[string]*checker.Result{
-				checker.PolicyList: checker.MakeResult(checker.PolicyList),
-			},
-		},
+		Domain:    "example.com",
+		Data:      checker.NewSampleDomainResult("example.com"),
 		Timestamp: time.Now(),
 		Version:   1,
 	}


### PR DESCRIPTION
Depends on #187 
Closes #146 

Two possible success paths:
1) they check the MTA-STS box and their most recent scan was successful with a successful MTA-STS check
    - In this case we can use the `PreferredHostnames` from their scan, which must be a subset of the hostnames listed in their MTA-STS policy file.
2) they provide hostnames, their most recent scan was successful, and the hostnames they provided are a subset of the `PreferredHostnames` in their scan.
