### PR TITLE
Store and retrieve stats for user scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - "1.11"
 
 addons:
-  postgresql: "9.5"
+  postgresql: "10"
 
 env:
   - TEST_DB_NAME=starttls_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ go:
 
 addons:
   postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
+env:
+  global:
+  - PGPORT=5433
 
 env:
   - TEST_DB_NAME=starttls_test

--- a/db/db.go
+++ b/db/db.go
@@ -37,6 +37,8 @@ type Database interface {
 	GetHostnameScan(string) (checker.HostnameResult, error)
 	// Enters a hostname scan.
 	PutHostnameScan(string, checker.HostnameResult) error
+	// Gets counts per day of hosts supporting MTA-STS adoption.
+	GetMTASTSStats() (models.TimeSeries, error)
 	ClearTables() error
 }
 

--- a/db/scripts/init_tables.sql
+++ b/db/scripts/init_tables.sql
@@ -72,3 +72,5 @@ CREATE TRIGGER update_change_timestamp BEFORE UPDATE
     update_changetimestamp_column();
 
 ALTER TABLE scans ADD COLUMN IF NOT EXISTS version INTEGER DEFAULT 0;
+
+ALTER TABLE scans ADD COLUMN IF NOT EXISTS mta_sts_mode TEXT DEFAULT '';

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -154,8 +154,7 @@ func (db *SQLDatabase) GetMTASTSStats() (models.TimeSeries, error) {
 		if err := rows.Scan(&t, &count); err != nil {
 			return nil, err
 		}
-		// @TODO think about timezones
-		ts[t.UTC()] = count
+		ts[t.Local()] = count
 	}
 	return ts, nil
 }

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -120,12 +120,15 @@ func (db *SQLDatabase) PutScan(scan models.Scan) error {
 // 14-day window.
 // Returns a map with
 //  key: the final day of a two-week window. Windows last until EOD.
-//  value: the number of scans supporting MTA-STS in that window
+//  value: the percent of scans supporting MTA-STS in that window
 func (db *SQLDatabase) GetMTASTSStats() (models.TimeSeries, error) {
 	// "day" represents truncated date (ie beginning of day), but windows should
 	// include the full day, so we add a day when querying timestamps.
 	query := `
-		SELECT day, count(*)
+		SELECT day, 100.0 * SUM(
+			CASE WHEN mta_sts_mode = 'testing' THEN 1 ELSE 0 END +
+			CASE WHEN mta_sts_mode = 'enforce' THEN 1 ELSE 0 END
+		) / COUNT(day) as percent
 		FROM (
 				SELECT date_trunc('day', d)::date AS day
 				FROM generate_series(CURRENT_DATE-31, CURRENT_DATE, '1 day'::INTERVAL) d )
@@ -136,7 +139,6 @@ func (db *SQLDatabase) GetMTASTSStats() (models.TimeSeries, error) {
 				WHERE timestamp BETWEEN day - '13 days'::INTERVAL AND day + '1 day'::INTERVAL
 				ORDER BY domain, timestamp DESC
 			) AS most_recent_scans ON TRUE
-		WHERE mta_sts_mode IN ('testing', 'enforce')
 		GROUP BY day;`
 
 	rows, err := db.conn.Query(query)
@@ -145,11 +147,10 @@ func (db *SQLDatabase) GetMTASTSStats() (models.TimeSeries, error) {
 	}
 	defer rows.Close()
 
-	var ts models.TimeSeries
-	ts = make(map[time.Time]int)
+	ts := make(map[time.Time]float32)
 	for rows.Next() {
 		var t time.Time
-		var count int
+		var count float32
 		if err := rows.Scan(&t, &count); err != nil {
 			return nil, err
 		}

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -405,7 +405,7 @@ func expectStats(ts models.TimeSeries, t *testing.T) {
 	// We need to truncate the expected times and convert to UTC for comparison.
 	expected := make(map[time.Time]float32)
 	for kOld, v := range ts {
-		k := kOld.UTC().Truncate(24 * time.Hour)
+		k := kOld.Truncate(24 * time.Hour)
 		expected[k] = v
 	}
 	got, err := database.GetMTASTSStats()

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -355,10 +355,14 @@ func TestGetMTASTSStats(t *testing.T) {
 	database.PutScan(s)
 	// Support is shown in the rolling average until the no-support scan is
 	// included.
-	expectStats(map[time.Time]int{
-		lastWeek:              1,
-		lastWeek.Add(day):     1,
-		lastWeek.Add(2 * day): 1,
+	expectStats(models.TimeSeries{
+		lastWeek:              100,
+		lastWeek.Add(day):     100,
+		lastWeek.Add(2 * day): 100,
+		lastWeek.Add(3 * day): 0,
+		lastWeek.Add(4 * day): 0,
+		lastWeek.Add(5 * day): 0,
+		lastWeek.Add(6 * day): 0,
 	}, t)
 
 	// Add another recent scan, from a second domain.
@@ -368,22 +372,38 @@ func TestGetMTASTSStats(t *testing.T) {
 		Timestamp: lastWeek.Add(1 * day),
 	}
 	database.PutScan(s)
-	expectStats(map[time.Time]int{
-		lastWeek:              1,
-		lastWeek.Add(day):     2,
-		lastWeek.Add(2 * day): 2,
-		lastWeek.Add(3 * day): 1,
-		lastWeek.Add(4 * day): 1,
-		lastWeek.Add(5 * day): 1,
-		lastWeek.Add(6 * day): 1,
+	expectStats(models.TimeSeries{
+		lastWeek:              100,
+		lastWeek.Add(day):     100,
+		lastWeek.Add(2 * day): 100,
+		lastWeek.Add(3 * day): 50,
+		lastWeek.Add(4 * day): 50,
+		lastWeek.Add(5 * day): 50,
+		lastWeek.Add(6 * day): 50,
 	}, t)
 
+	// Add a third scan to check that floats are outputted correctly.
+	s = models.Scan{
+		Domain:    "example3.com",
+		Data:      checker.NewSampleDomainResult("example2.com"),
+		Timestamp: lastWeek.Add(6 * day),
+	}
+	database.PutScan(s)
+	expectStats(models.TimeSeries{
+		lastWeek:              100,
+		lastWeek.Add(day):     100,
+		lastWeek.Add(2 * day): 100,
+		lastWeek.Add(3 * day): 50,
+		lastWeek.Add(4 * day): 50,
+		lastWeek.Add(5 * day): 50,
+		lastWeek.Add(6 * day): 66.666664,
+	}, t)
 }
 
 func expectStats(ts models.TimeSeries, t *testing.T) {
 	// GetMTASTSStats returns dates only (no hours, minutes, seconds).
 	// We need to truncate the expected times and convert to UTC for comparison.
-	expected := make(map[time.Time]int)
+	expected := make(map[time.Time]float32)
 	for kOld, v := range ts {
 		k := kOld.UTC().Truncate(24 * time.Hour)
 		expected[k] = v

--- a/models/timeseries.go
+++ b/models/timeseries.go
@@ -2,4 +2,5 @@ package models
 
 import "time"
 
-type TimeSeries map[time.Time]int
+// TimeSeries holds dates with associated numerical values, for charting.
+type TimeSeries map[time.Time]float32

--- a/models/timeseries.go
+++ b/models/timeseries.go
@@ -1,0 +1,5 @@
+package models
+
+import "time"
+
+type TimeSeries map[time.Time]int


### PR DESCRIPTION
I got a bit nerd sniped trying to write this as a single query, oops. I think it's okay for now and if we want to prune scans at some point we can write some aggregated stats to the DB. 

Note about timezones: Postgres returns timestamps with a zero offset from UTC and no timezone (since UTC isn't the only timezone with that offset, it doesn't want to assume). `time.Now()` gives us local time, so I set the Postgres return values to local time as well. We're not checking what timezone our visitors are in, so we might as well use ours :)

I think we should cache this query, since the result will almost always been the same or almost the same. We could use a simple in-memory cache like https://github.com/patrickmn/go-cache.