### PR TITLE
Store and retrieve stats for user scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - "1.11"
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
 
 env:
   - TEST_DB_NAME=starttls_test

--- a/db/db.go
+++ b/db/db.go
@@ -37,6 +37,8 @@ type Database interface {
 	GetHostnameScan(string) (checker.HostnameResult, error)
 	// Enters a hostname scan.
 	PutHostnameScan(string, checker.HostnameResult) error
+	// Gets counts per day of hosts supporting MTA-STS adoption.
+	GetMTASTSStats() (models.TimeSeries, error)
 	ClearTables() error
 }
 

--- a/db/scripts/init_tables.sql
+++ b/db/scripts/init_tables.sql
@@ -72,3 +72,5 @@ CREATE TRIGGER update_change_timestamp BEFORE UPDATE
     update_changetimestamp_column();
 
 ALTER TABLE scans ADD COLUMN IF NOT EXISTS version INTEGER DEFAULT 0;
+
+ALTER TABLE scans ADD COLUMN IF NOT EXISTS mta_sts_mode TEXT DEFAULT '';

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -124,6 +124,8 @@ func (db *SQLDatabase) PutScan(scan models.Scan) error {
 func (db *SQLDatabase) GetMTASTSStats() (models.TimeSeries, error) {
 	// "day" represents truncated date (ie beginning of day), but windows should
 	// include the full day, so we add a day when querying timestamps.
+	// Getting the most recent 31 days for now, we can set the start date to the
+	// beginning of our MTA-STS data once we have some.
 	query := `
 		SELECT day, 100.0 * SUM(
 			CASE WHEN mta_sts_mode = 'testing' THEN 1 ELSE 0 END +

--- a/models/timeseries.go
+++ b/models/timeseries.go
@@ -2,4 +2,5 @@ package models
 
 import "time"
 
-type TimeSeries map[time.Time]int
+// TimeSeries holds dates with associated numerical values, for charting.
+type TimeSeries map[time.Time]float32

--- a/models/timeseries.go
+++ b/models/timeseries.go
@@ -1,0 +1,5 @@
+package models
+
+import "time"
+
+type TimeSeries map[time.Time]int


### PR DESCRIPTION
I got a bit nerd sniped trying to write this as a single query! I think it's fine for now and if we want to prune scans at some point we can write some aggregated stats to the DB.

Postgres returns timestamps with a zero offset from UTC and no timezone (since UTC isn't the only timezone with that offset, it doesn't want to assume). I'm giving it an explicit "UTC" timezone for easier to comparison. I considered converting to local time, but that would mess with the idea of which events occured on which date, which was calculated in the database with a zero offset from UTC.

I think we should cache this, since the result will almost always be close enough. We could probably set a header in the handler and then cache the whole response using nginx (my preference) or use a simple in-memory cache like https://github.com/patrickmn/go-cache.

I needed to upgrade Travis to use Posgres 9.6 to support `ADD COLUMN IF NOT EXISTS`. Unfortunately it doesn't support 10 out of the box yet so we can't match it to the Dockerfile.

Closes #177
Closes #178 