### PR TITLE
Make hostname result cache safe for concurrent use

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -13,6 +13,7 @@ type Checker struct {
 	Timeout time.Duration
 
 	// Cache specifies the hostname scan cache store and expire time.
+	// If `nil`, then scans are not cached.
 	Cache *ScanCache
 
 	// lookupMX specifies an alternate function to retrieve hostnames for a given

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -13,7 +13,6 @@ type Checker struct {
 	Timeout time.Duration
 
 	// Cache specifies the hostname scan cache store and expire time.
-	// Defaults to a 10-minute in-memory cache.
 	Cache *ScanCache
 
 	// lookupMX specifies an alternate function to retrieve hostnames for a given
@@ -32,11 +31,4 @@ func (c *Checker) timeout() time.Duration {
 		return c.Timeout
 	}
 	return 10 * time.Second
-}
-
-func (c *Checker) cache() *ScanCache {
-	if c.Cache == nil {
-		c.Cache = MakeSimpleCache(10 * time.Minute)
-	}
-	return c.Cache
 }

--- a/checker/domain.go
+++ b/checker/domain.go
@@ -120,12 +120,7 @@ func (c *Checker) CheckDomain(domain string, expectedHostnames []string) DomainR
 	}
 	checkedHostnames := make([]string, 0)
 	for _, hostname := range hostnames {
-		cache := c.cache()
-		hostnameResult, err := cache.GetHostnameScan(hostname)
-		if err != nil {
-			hostnameResult = c.CheckHostname(domain, hostname)
-			cache.PutHostnameScan(hostname, hostnameResult)
-		}
+		hostnameResult := c.CheckHostnameWithCache(domain, hostname)
 		result.HostnameResults[hostname] = hostnameResult
 		if hostnameResult.couldConnect() {
 			checkedHostnames = append(checkedHostnames, hostname)

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -210,6 +210,20 @@ func checkTLSVersion(client *smtp.Client, hostname string, timeout time.Duration
 	return result.Success()
 }
 
+// CheckHostnameWithCache returns the result of CheckHostname, using or
+// updating the Checker's cache.
+func (c *Checker) CheckHostnameWithCache(domain string, hostname string) HostnameResult {
+	if c.Cache == nil {
+		return c.CheckHostname(domain, hostname)
+	}
+	hostnameResult, err := c.Cache.GetHostnameScan(hostname)
+	if err != nil {
+		hostnameResult = c.CheckHostname(domain, hostname)
+		c.Cache.PutHostnameScan(hostname, hostnameResult)
+	}
+	return hostnameResult
+}
+
 // CheckHostname performs a series of checks against a hostname for an email domain.
 // `domain` is the mail domain that this server serves email for.
 // `hostname` is the hostname for this server.

--- a/validator/validate.go
+++ b/validator/validate.go
@@ -62,6 +62,8 @@ func validateRegularly(v DomainPolicyStore, interval time.Duration,
 // Hostname map. Interval specifies the interval to wait between each run.
 // Failures are reported to Sentry.
 func ValidateRegularly(v DomainPolicyStore, interval time.Duration) {
-	c := checker.Checker{}
+	c := checker.Checker{
+		Cache: checker.MakeSimpleCache(10 * time.Minute),
+	}
 	validateRegularly(v, interval, c.CheckDomain, reportToSentry)
 }


### PR DESCRIPTION
* Add a mutex to the cache
* Don't lazy init the cache on the checker. Unfortunately I don't think there's a way to do this that won't cause a race, short of adding a mutex to the checker. Since we're actually only using the default in one place I just made the default be no cache and created the cache explicitly there.

Also, the tests you wrote for checking domains helped me find a major bug just as I was getting ready to open this! Thank you :D