### PR TITLE
Can queue MTA-STS domain with "Warning" notice

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,6 +121,5 @@ func main() {
 		log.Println("[Starting queued validator]")
 		go validator.ValidateRegularly("Testing domains", db, 24*time.Hour)
 	}
-	go validator.ValidateRegularly("", db, 24*time.Hour)
 	ServePublicEndpoints(&api, &cfg)
 }

--- a/main.go
+++ b/main.go
@@ -121,5 +121,6 @@ func main() {
 		log.Println("[Starting queued validator]")
 		go validator.ValidateRegularly("Testing domains", db, 24*time.Hour)
 	}
+	go validator.ValidateRegularly("", db, 24*time.Hour)
 	ServePublicEndpoints(&api, &cfg)
 }

--- a/models/scan.go
+++ b/models/scan.go
@@ -36,5 +36,5 @@ func (s Scan) SupportsMTASTS() bool {
 	if s.Data.MTASTSResult == nil {
 		return false
 	}
-	return s.Data.MTASTSResult.Status == checker.Success
+	return s.Data.MTASTSResult.Status == checker.Success || s.Data.MTASTSResult == checker.Warning
 }

--- a/models/scan.go
+++ b/models/scan.go
@@ -36,5 +36,5 @@ func (s Scan) SupportsMTASTS() bool {
 	if s.Data.MTASTSResult == nil {
 		return false
 	}
-	return s.Data.MTASTSResult.Status == checker.Success || s.Data.MTASTSResult == checker.Warning
+	return s.Data.MTASTSResult.Status == checker.Success || s.Data.MTASTSResult.Status == checker.Warning
 }


### PR DESCRIPTION
So long as the policy itself does validate, even if it's in testing mode, let's allow folks to queue their domains.

The only two types of failures where a "Warning" would be returned are for "testing" mode and when the content type isn't `text/plain`.