### PR TITLE
Dockerfile for checker

### DIFF
--- a/checker/Dockerfile
+++ b/checker/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.11-alpine
+
+WORKDIR /go/src/github.com/EFForg/starttls-backend/checker
+
+RUN apk add git
+
+ADD . .
+
+RUN go get github.com/EFForg/starttls-backend/checker/cmd/starttls-check
+
+CMD ["/go/bin/starttls-check"]

--- a/checker/totals.go
+++ b/checker/totals.go
@@ -76,6 +76,7 @@ func (c *Checker) CheckCSV(domains *csv.Reader, resultHandler ResultHandler, dom
 			data, err := domains.Read()
 			if err != nil {
 				if err != io.EOF {
+					log.Println("Error reading CSV")
 					log.Fatal(err)
 				}
 				break


### PR DESCRIPTION
Depends on #206 

I decided to give the checker its own Dockerfile because it builds a different binary and could have different dependencies. We could build two binaries in the existing Dockerfile but it seemed more consistent with the Docker philosophy to have a single-application image.

This can run daily scans with a `checker/docker-compose.yml` like 
```
services:
    app:
        build: .
        environment:
          - CONNECTION_POOL_SIZE=32
        volumes:
          - ./shared:/shared
        command: /bin/sh -c 'env >> /etc/environment && crontab /shared/check.cron && crond -f'
```
and a `checker/shared/check.cron` like
```
0 15 * * * /go/bin/starttls-check --file=/shared/majestic_million.csv --column=2 --aggregate=true >> /shared/stats.csv
```

I'd like to commit those to a deploy repo managed by techops.