### PR TITLE
Import stats as JSON

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,5 @@ AMAZON_AUTHORIZE_KEY=
 SENTRY_URL=
 
 FRONTEND_WEBSITE_LINK=
+# Url aggregated scan results, for importing results of our scans of top domains
+REMOTE_STATS_URL=

--- a/checker/cmd/starttls-check/cmd.go
+++ b/checker/cmd/starttls-check/cmd.go
@@ -91,10 +91,8 @@ func main() {
 			Source: label,
 		}
 	}
-	// Assume domains are in the 0th column, eg just a newline-separated list
-	// of domains. Could pass this is a flag.
 	c.CheckCSV(domainReader, resultHandler, *column)
-	fmt.Fprintln(out, resultHandler)
+	json.NewEncoder(out).Encode(resultHandler)
 }
 
 type domainWriter struct{}

--- a/checker/cmd/starttls-check/cmd_test.go
+++ b/checker/cmd/starttls-check/cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,13 +31,21 @@ func TestUpdateStats(t *testing.T) {
 	// @TODO make this faster
 	main()
 	got := out.(*bytes.Buffer).String()
-	expected := checker.AggregatedScan{
+	expected, err := json.Marshal(checker.AggregatedScan{
 		Time:      time.Time{},
 		Source:    ts.URL,
 		Attempted: 3,
-	}.String()
-	expected = strings.Replace(expected, time.Time{}.String(), ".*", 1)
-	re := regexp.MustCompile(expected)
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	timeJSON, err := json.Marshal(time.Time{})
+	if err != nil {
+		t.Error(err)
+	}
+	re := regexp.MustCompile(
+		strings.Replace(string(expected), string(timeJSON), ".*", 1),
+	)
 
 	if !re.MatchString(got) {
 		t.Errorf("Expected:\n%s\nGot:\n%s", expected, got)

--- a/checker/cmd/starttls-check/cmd_test.go
+++ b/checker/cmd/starttls-check/cmd_test.go
@@ -37,11 +37,11 @@ func TestUpdateStats(t *testing.T) {
 		Attempted: 3,
 	})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	timeJSON, err := json.Marshal(time.Time{})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	re := regexp.MustCompile(
 		strings.Replace(string(expected), string(timeJSON), ".*", 1),

--- a/checker/totals.go
+++ b/checker/totals.go
@@ -2,12 +2,10 @@ package checker
 
 import (
 	"encoding/csv"
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -47,12 +45,6 @@ func (a *AggregatedScan) HandleDomain(r DomainResult) {
 			a.MTASTSTestingList = append(a.MTASTSTestingList, r.Domain)
 		}
 	}
-}
-
-func (a AggregatedScan) String() string {
-	s := strings.Join([]string{"time", "source", "attempted", "with_mxs", "mta_sts_testing", "mta_sts_enforce"}, "\t") + "\n"
-	s += fmt.Sprintf("%v\t%s\t%d\t%d\t%d\t%d\n", a.Time, a.Source, a.Attempted, a.WithMXs, len(a.MTASTSTestingList), len(a.MTASTSEnforceList))
-	return s
 }
 
 // ResultHandler processes domain results.

--- a/db/db.go
+++ b/db/db.go
@@ -31,6 +31,8 @@ type Database interface {
 	GetHostnameScan(string) (checker.HostnameResult, error)
 	// Enters a hostname scan.
 	PutHostnameScan(string, checker.HostnameResult) error
+	// Writes an aggregated scan to the database
+	PutAggregatedScan(checker.AggregatedScan) error
 	// Gets counts per day of hosts supporting MTA-STS adoption.
 	GetMTASTSStats() (models.TimeSeries, error)
 	// Upserts domain state.

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -379,3 +379,12 @@ func (db *SQLDatabase) PutHostnameScan(hostname string, result checker.HostnameR
                                 VALUES($1, $2, $3)`, hostname, result.Status, string(data))
 	return err
 }
+
+// PutAggregatedScan writes and AggregatedScan to the db.
+func (db *SQLDatabase) PutAggregatedScan(a checker.AggregatedScan) error {
+	_, err := db.conn.Exec(`INSERT INTO
+		aggregated_scans(time, source, attempted, with_mxs, mta_sts_testing, mta_sts_enforce)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		a.Time, a.Source, a.Attempted, a.WithMXs, a.MTASTSTesting, a.MTASTSEnforce)
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/EFForg/starttls-backend/db"
 	"github.com/EFForg/starttls-backend/policy"
+	"github.com/EFForg/starttls-backend/stats"
 	"github.com/EFForg/starttls-backend/validator"
 
 	"github.com/getsentry/raven-go"
@@ -121,5 +122,6 @@ func main() {
 		log.Println("[Starting queued validator]")
 		go validator.ValidateRegularly("Testing domains", db, 24*time.Hour)
 	}
+	go stats.ImportRegularly(db, time.Hour)
 	ServePublicEndpoints(&api, &cfg)
 }

--- a/stats/import.go
+++ b/stats/import.go
@@ -1,0 +1,41 @@
+package stats
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/EFForg/starttls-backend/checker"
+	raven "github.com/getsentry/raven-go"
+)
+
+var statsURL = "https://stats.starttls-everywhere.org/mta-sts-adoption.csv"
+
+// Store wraps storage for MTA-STS adoption statistics.
+type Store interface {
+	PutAggregatedScan(checker.AggregatedScan) error
+}
+
+// Import imports JSON list of aggregated scans from a remote server to the
+// datastore.
+func Import(store Store) {
+	resp, err := http.Get(statsURL)
+	if err != nil {
+		raven.CaptureError(err, nil)
+		return
+	}
+	defer resp.Body.Close()
+
+	var agScans []checker.AggregatedScan
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&agScans)
+	if err != nil {
+		raven.CaptureError(err, nil)
+		return
+	}
+	for _, a := range agScans {
+		err := store.PutAggregatedScan(a)
+		if err != nil {
+			raven.CaptureError(err, nil)
+		}
+	}
+}

--- a/stats/import.go
+++ b/stats/import.go
@@ -3,13 +3,12 @@ package stats
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
 	raven "github.com/getsentry/raven-go"
 )
-
-var statsURL = "https://stats.starttls-everywhere.org/mta-sts-adoption.csv"
 
 // Store wraps storage for MTA-STS adoption statistics.
 type Store interface {
@@ -19,6 +18,7 @@ type Store interface {
 // Import imports JSON list of aggregated scans from a remote server to the
 // datastore.
 func Import(store Store) {
+	statsURL := os.Getenv("REMOTE_STATS_URL")
 	resp, err := http.Get(statsURL)
 	if err != nil {
 		raven.CaptureError(err, nil)

--- a/stats/import.go
+++ b/stats/import.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
 	raven "github.com/getsentry/raven-go"
@@ -37,5 +38,13 @@ func Import(store Store) {
 		if err != nil {
 			raven.CaptureError(err, nil)
 		}
+	}
+}
+
+// ImportRegularly runs Import to import aggregated stats from a remote server at regular intervals.
+func ImportRegularly(store Store, interval time.Duration) {
+	for {
+		<-time.After(interval)
+		Import(store)
 	}
 }

--- a/stats/import_test.go
+++ b/stats/import_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -42,7 +43,7 @@ func TestImportAggregatedScans(t *testing.T) {
 			json.NewEncoder(w).Encode(agScans)
 		}),
 	)
-	statsURL = ts.URL
+	os.Setenv("REMOTE_STATS_URL", ts.URL)
 	store := mockAgScanStore{}
 	Import(&store)
 	for i, want := range agScans {

--- a/stats/import_test.go
+++ b/stats/import_test.go
@@ -1,0 +1,60 @@
+package stats
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/EFForg/starttls-backend/checker"
+)
+
+type mockAgScanStore []checker.AggregatedScan
+
+func (m *mockAgScanStore) PutAggregatedScan(agScan checker.AggregatedScan) error {
+	*m = append(*m, agScan)
+	return nil
+}
+
+func TestImportAggregatedScans(t *testing.T) {
+	agScans := []checker.AggregatedScan{
+		checker.AggregatedScan{
+			Time:          time.Now().Add(-24 * time.Hour),
+			Source:        "domains-depot",
+			Attempted:     4,
+			WithMXs:       3,
+			MTASTSTesting: 2,
+			MTASTSEnforce: 1,
+		},
+		checker.AggregatedScan{
+			Time:          time.Now(),
+			Source:        "domains-depot",
+			Attempted:     8,
+			WithMXs:       7,
+			MTASTSTesting: 6,
+			MTASTSEnforce: 5,
+		},
+	}
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(agScans)
+		}),
+	)
+	statsURL = ts.URL
+	store := mockAgScanStore{}
+	Import(&store)
+	for i, want := range agScans {
+		got := store[i]
+		// Times must be compared with Time.Equal, so we can't reflect.DeepEqual yet.
+		if !want.Time.Equal(got.Time) {
+			t.Errorf("\nExpected\n %v\nGot\n %v", agScans, store)
+		}
+		got.Time = time.Time{}
+		want.Time = time.Time{}
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("\nExpected\n %v\nGot\n %v", agScans, store)
+		}
+	}
+}


### PR DESCRIPTION
* Import stats from our scans of the web!
* I switched this communicate via JSON rather than a CSV, since Go's built-in handling of JSON is so much better. The main drawback is that it's not possible to maintain a valid JSON list by simply appending lines of new data to the end. I'm going to try to handle that with a little bit of sed magic in the cron job on the stats server.