### PR TITLE
Use JSONL format for aggregated scans

### DIFF
--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -45,12 +45,17 @@ func TestImport(t *testing.T) {
 	}
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewEncoder(w).Encode(agScans)
+			enc := json.NewEncoder(w)
+			enc.Encode(agScans[0])
+			enc.Encode(agScans[1])
 		}),
 	)
 	os.Setenv("REMOTE_STATS_URL", ts.URL)
 	store := mockAgScanStore{}
-	Import(&store)
+	err := Import(&store)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i, want := range agScans {
 		got := store[i]
 		// Times must be compared with Time.Equal, so we can't reflect.DeepEqual.


### PR DESCRIPTION
Expect JSON lines (http://jsonlines.org/) format for incoming aggregated scan data. This makes it much easier to append log lines when running scans.