### PR TITLE
Bugfix: increment MTA-STS totals

### DIFF
--- a/checker/totals.go
+++ b/checker/totals.go
@@ -40,8 +40,10 @@ func (a *AggregatedScan) HandleDomain(r DomainResult) {
 	if r.MTASTSResult != nil {
 		switch r.MTASTSResult.Mode {
 		case "enforce":
+			a.MTASTSEnforce++
 			a.MTASTSEnforceList = append(a.MTASTSEnforceList, r.Domain)
 		case "testing":
+			a.MTASTSTesting++
 			a.MTASTSTestingList = append(a.MTASTSTestingList, r.Domain)
 		}
 	}


### PR DESCRIPTION
When conducting an aggregated scan, we need to increment the totals of domains in mta-sts testing and enforce mode.