### PR TITLE
Format stats for frontend

### DIFF
--- a/checker/totals.go
+++ b/checker/totals.go
@@ -22,10 +22,15 @@ type AggregatedScan struct {
 	MTASTSEnforceList []string
 }
 
+// TotalMTASTS returns the number of domains supporting test or enforce mode.
+func (a AggregatedScan) TotalMTASTS() int {
+	return a.MTASTSTesting + a.MTASTSEnforce
+}
+
 // PercentMTASTS returns the fraction of domains with MXs that support
 // MTA-STS, represented as a float between 0 and 1.
 func (a AggregatedScan) PercentMTASTS() float64 {
-	return (float64(a.MTASTSTesting) + float64(a.MTASTSEnforce)) / float64(a.WithMXs)
+	return float64(a.TotalMTASTS()) / float64(a.WithMXs)
 }
 
 // HandleDomain adds the result of a single domain scan to aggregated stats.

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -132,7 +132,7 @@ func (db *SQLDatabase) GetMTASTSStats(source string) (stats.Series, error) {
 		if err := rows.Scan(&a.Time, &a.WithMXs, &a.MTASTSTesting, &a.MTASTSEnforce); err != nil {
 			return stats.Series{}, err
 		}
-		series[a.Time.UTC()] = a.PercentMTASTS()
+		series[a.Time.UTC()] = float64(a.TotalMTASTS())
 	}
 	return series, nil
 }

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -386,7 +386,7 @@ func TestGetMTASTSStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result[may1] != float64(0.75) || result[may2] != float64(0.5) {
+	if result[may1] != 3 || result[may2] != 4 {
 		t.Errorf("Incorrect MTA-STS stats, got %v", result)
 	}
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -71,6 +71,7 @@ func ImportRegularly(store Store, interval time.Duration) {
 type Series map[time.Time]float64
 
 // MarshalJSON marshals a Series to the format expected by chart.js.
+// See https://www.chartjs.org/docs/latest/
 func (s Series) MarshalJSON() ([]byte, error) {
 	type xyPt struct {
 		X time.Time `json:"x"`

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
@@ -67,6 +68,22 @@ func ImportRegularly(store Store, interval time.Duration) {
 // library prefers.
 type Series map[time.Time]float64
 
+// MarshalJSON marshals a Series to the format expected by chart.js.
+func (s Series) MarshalJSON() ([]byte, error) {
+	type xyPt struct {
+		X time.Time `json:"x"`
+		Y float64   `json:"y"`
+	}
+	xySeries := make([]xyPt, 0)
+	for x, y := range s {
+		xySeries = append(xySeries, xyPt{X: x, Y: y})
+	}
+	sort.Slice(xySeries, func(i, j int) bool {
+		return xySeries[i].X.After(xySeries[j].X)
+	})
+	return json.Marshal(xySeries)
+}
+
 // Get retrieves MTA-STS adoption statistics for user-initiated scans and scans
 // of the top million domains over time.
 func Get(store Store) (map[string]Series, error) {
@@ -75,7 +92,7 @@ func Get(store Store) (map[string]Series, error) {
 	if err != nil {
 		return result, err
 	}
-	result["top-million"] = series
+	result["top_million"] = series
 	series, err = store.GetMTASTSLocalStats()
 	if err != nil {
 		return result, err

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -56,10 +56,12 @@ func Import(store Store) error {
 // ImportRegularly runs Import to import aggregated stats from a remote server at regular intervals.
 func ImportRegularly(store Store, interval time.Duration) {
 	for {
-		<-time.After(interval)
 		err := Import(store)
-		log.Println(err)
-		raven.CaptureError(err, nil)
+		if err != nil {
+			log.Println(err)
+			raven.CaptureError(err, nil)
+		}
+		<-time.After(interval)
 	}
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -37,8 +37,12 @@ func TestGetStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	date := now.UTC().Truncate(24 * time.Hour).Format(time.RFC3339)
-	expected := fmt.Sprintf("\"%v\": 100", date)
-	if !strings.Contains(string(body), expected) {
-		t.Errorf("Expected %s to contain %s", string(body), expected)
+	expectedX := fmt.Sprintf("\"x\": \"%v\"", date)
+	if !strings.Contains(string(body), expectedX) {
+		t.Errorf("Expected %s to contain %s", string(body), expectedX)
+	}
+	expectedY := fmt.Sprintf("\"y\": 100")
+	if !strings.Contains(string(body), expectedY) {
+		t.Errorf("Expected %s to contain %s", string(body), expectedY)
 	}
 }


### PR DESCRIPTION
* Serve domain count rather than percent for top-million scan
* Serve data to chart as a json array of x-y coordinates, sorted along the x axis