### PR TITLE
Simplify query for user-initiated scan stats

### DIFF
--- a/checker/totals.go
+++ b/checker/totals.go
@@ -30,7 +30,10 @@ func (a AggregatedScan) TotalMTASTS() int {
 // PercentMTASTS returns the fraction of domains with MXs that support
 // MTA-STS, represented as a float between 0 and 1.
 func (a AggregatedScan) PercentMTASTS() float64 {
-	return float64(a.TotalMTASTS()) / float64(a.WithMXs)
+	if a.WithMXs == 0 {
+		return 0
+	}
+	return 100 * float64(a.TotalMTASTS()) / float64(a.WithMXs)
 }
 
 // HandleDomain adds the result of a single domain scan to aggregated stats.

--- a/db/db.go
+++ b/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"flag"
 	"os"
+	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
 	"github.com/EFForg/starttls-backend/models"
@@ -34,6 +35,8 @@ type Database interface {
 	PutHostnameScan(string, checker.HostnameResult) error
 	// Writes an aggregated scan to the database
 	PutAggregatedScan(checker.AggregatedScan) error
+	// Caches stats for the 14 days preceding time.Time
+	PutLocalStats(time.Time) (checker.AggregatedScan, error)
 	// Gets counts per day of hosts supporting MTA-STS for a given source.
 	GetMTASTSStats(string) (stats.Series, error)
 	// Upserts domain state.

--- a/db/db.go
+++ b/db/db.go
@@ -38,7 +38,7 @@ type Database interface {
 	// Caches stats for the 14 days preceding time.Time
 	PutLocalStats(time.Time) (checker.AggregatedScan, error)
 	// Gets counts per day of hosts supporting MTA-STS for a given source.
-	GetMTASTSStats(string) (stats.Series, error)
+	GetStats(string) (stats.Series, error)
 	// Upserts domain state.
 	PutDomain(models.Domain) error
 	// Retrieves state of a domain

--- a/db/db.go
+++ b/db/db.go
@@ -36,8 +36,6 @@ type Database interface {
 	PutAggregatedScan(checker.AggregatedScan) error
 	// Gets counts per day of hosts supporting MTA-STS for a given source.
 	GetMTASTSStats(string) (stats.Series, error)
-	// Gets counts per day of hosts scanned by this app supporting MTA-STS adoption.
-	GetMTASTSLocalStats() (stats.Series, error)
 	// Upserts domain state.
 	PutDomain(models.Domain) error
 	// Retrieves state of a domain

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -165,7 +165,7 @@ func (db *SQLDatabase) PutLocalStats(date time.Time) (checker.AggregatedScan, er
 		Source: "local",
 		Time:   date,
 	}
-	err := db.conn.QueryRow(query, start, end).Scan(&a.WithMXs, &a.MTASTSTesting, &a.MTASTSEnforce)
+	err := db.conn.QueryRow(query, start.UTC(), end.UTC()).Scan(&a.WithMXs, &a.MTASTSTesting, &a.MTASTSEnforce)
 	if err != nil {
 		return a, err
 	}

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -117,9 +117,9 @@ func (db *SQLDatabase) PutScan(scan models.Scan) error {
 	return err
 }
 
-// GetMTASTSStats returns statistics about a MTA-STS adoption from a single
+// GetStats returns statistics about a MTA-STS adoption from a single
 // source domains to check.
-func (db *SQLDatabase) GetMTASTSStats(source string) (stats.Series, error) {
+func (db *SQLDatabase) GetStats(source string) (stats.Series, error) {
 	series := stats.Series{}
 	rows, err := db.conn.Query(
 		`SELECT time, with_mxs, mta_sts_testing, mta_sts_enforce

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -391,6 +391,33 @@ func TestGetMTASTSStats(t *testing.T) {
 	}
 }
 
+func TestPutLocalStats(t *testing.T) {
+	database.ClearTables()
+	percent, err := database.PutLocalStats(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if percent != 0 {
+		t.Error()
+	}
+	day := time.Hour * 24
+	today := time.Now()
+	lastWeek := today.Add(-6 * day)
+	s := models.Scan{
+		Domain:    "example1.com",
+		Data:      checker.NewSampleDomainResult("example1.com"),
+		Timestamp: lastWeek,
+	}
+	database.PutScan(s)
+	percent, err = database.PutLocalStats(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if percent != 100 {
+		t.Error(percent)
+	}
+}
+
 func TestGetMTASTSLocalStats(t *testing.T) {
 	database.ClearTables()
 	day := time.Hour * 24

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -431,7 +431,7 @@ func TestGetLocalStats(t *testing.T) {
 	s := models.Scan{
 		Domain:    "example1.com",
 		Data:      checker.NewSampleDomainResult("example1.com"),
-		Timestamp: lastWeek,
+		Timestamp: lastWeek.Add(1 * day),
 	}
 	database.PutScan(s)
 	s.Timestamp = lastWeek.Add(3 * day)
@@ -442,7 +442,7 @@ func TestGetLocalStats(t *testing.T) {
 	s = models.Scan{
 		Domain:    "example2.com",
 		Data:      checker.NewSampleDomainResult("example2.com"),
-		Timestamp: lastWeek.Add(1 * day),
+		Timestamp: lastWeek.Add(2 * day),
 	}
 	database.PutScan(s)
 
@@ -450,7 +450,7 @@ func TestGetLocalStats(t *testing.T) {
 	s = models.Scan{
 		Domain:    "example3.com",
 		Data:      checker.NewSampleDomainResult("example2.com"),
-		Timestamp: lastWeek.Add(5 * day),
+		Timestamp: lastWeek.Add(6 * day),
 	}
 	database.PutScan(s)
 
@@ -465,7 +465,7 @@ func TestGetLocalStats(t *testing.T) {
 	}
 
 	// Validate result
-	expPcts := []float64{0, 100, 100, 100, 50, 50, 100 * 2 / float64(3)}
+	expPcts := []float64{0, 100, 100, 50, 50, 50, 100 * 2 / float64(3)}
 	if len(expPcts) != 7 {
 		t.Errorf("Expected 7 stats, got\n %v\n", stats)
 	}

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -353,7 +353,7 @@ func dateMustParse(date string, t *testing.T) time.Time {
 	return parsed
 }
 
-func TestGetMTASTSStats(t *testing.T) {
+func TestGetStats(t *testing.T) {
 	database.ClearTables()
 	may1 := dateMustParse("2019-May-01", t)
 	may2 := dateMustParse("2019-May-02", t)
@@ -381,7 +381,7 @@ func TestGetMTASTSStats(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	result, err := database.GetMTASTSStats("domains-depot")
+	result, err := database.GetStats("domains-depot")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestGetLocalStats(t *testing.T) {
 		database.PutLocalStats(lastWeek.Add(day * time.Duration(i)))
 	}
 
-	stats, err := database.GetMTASTSStats("local")
+	stats, err := database.GetStats("local")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -393,12 +393,13 @@ func TestGetMTASTSStats(t *testing.T) {
 
 func TestPutLocalStats(t *testing.T) {
 	database.ClearTables()
-	percent, err := database.PutLocalStats(time.Now())
+	a, err := database.PutLocalStats(time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if percent != 0 {
-		t.Error()
+	if a.PercentMTASTS() != 0 {
+		t.Errorf("Expected PercentMTASTS with no recent scans to be 0, got %v",
+			a.PercentMTASTS())
 	}
 	day := time.Hour * 24
 	today := time.Now()
@@ -409,12 +410,13 @@ func TestPutLocalStats(t *testing.T) {
 		Timestamp: lastWeek,
 	}
 	database.PutScan(s)
-	percent, err = database.PutLocalStats(time.Now())
+	a, err = database.PutLocalStats(time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if percent != 100 {
-		t.Error(percent)
+	if a.PercentMTASTS() != 100 {
+		t.Errorf("Expected PercentMTASTS with one recent scan to be 100, got %v",
+			a.PercentMTASTS())
 	}
 }
 

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -293,7 +293,7 @@ func TestHostnamesForDomain(t *testing.T) {
 }
 
 func TestPutAndIsBlacklistedEmail(t *testing.T) {
-	defer database.ClearTables()
+	database.ClearTables()
 
 	// Add an e-mail address to the blacklist.
 	err := database.PutBlacklistedEmail("fail@example.com", "bounce", "2017-07-21T18:47:13.498Z")

--- a/main.go
+++ b/main.go
@@ -122,6 +122,6 @@ func main() {
 		log.Println("[Starting queued validator]")
 		go validator.ValidateRegularly("Testing domains", db, 24*time.Hour)
 	}
-	go stats.ImportRegularly(db, time.Hour)
+	go stats.UpdateRegularly(db, time.Hour)
 	ServePublicEndpoints(&api, &cfg)
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
@@ -17,7 +16,6 @@ import (
 type Store interface {
 	PutAggregatedScan(checker.AggregatedScan) error
 	GetMTASTSStats(string) (Series, error)
-	GetMTASTSLocalStats() (Series, error)
 }
 
 // Identifier in the DB for aggregated scans we imported from our regular scans
@@ -68,7 +66,7 @@ func ImportRegularly(store Store, interval time.Duration) {
 // Series represents some statistic as it changes over time.
 // This will likely be updated when we know what format our frontend charting
 // library prefers.
-type Series map[time.Time]checker.AggregatedScan
+type Series []checker.AggregatedScan
 
 // MarshalJSON marshals a Series to the format expected by chart.js.
 func (s Series) MarshalJSON() ([]byte, error) {
@@ -77,7 +75,7 @@ func (s Series) MarshalJSON() ([]byte, error) {
 		Y float64   `json:"y"`
 	}
 	xySeries := make([]xyPt, 0)
-	for t, a := range s {
+	for _, a := range s {
 		var y float64
 		if a.Source != topDomainsSource {
 			y = a.PercentMTASTS()
@@ -86,11 +84,8 @@ func (s Series) MarshalJSON() ([]byte, error) {
 			// display a raw total instead.
 			y = float64(a.TotalMTASTS())
 		}
-		xySeries = append(xySeries, xyPt{X: t, Y: y})
+		xySeries = append(xySeries, xyPt{X: a.Time, Y: y})
 	}
-	sort.Slice(xySeries, func(i, j int) bool {
-		return xySeries[i].X.After(xySeries[j].X)
-	})
 	return json.Marshal(xySeries)
 }
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -16,14 +16,14 @@ import (
 type Store interface {
 	PutAggregatedScan(checker.AggregatedScan) error
 	PutLocalStats(time.Time) (checker.AggregatedScan, error)
-	GetMTASTSStats(string) (Series, error)
+	GetStats(string) (Series, error)
 }
 
 // Identifier in the DB for aggregated scans we imported from our regular scans
 // of the web's top domains
 const topDomainsSource = "TOP_DOMAINS"
 
-// Update imports aggregated scans from a remote server to the datastore.
+// Import imports aggregated scans from a remote server to the datastore.
 // Expected format is JSONL (newline-separated JSON objects).
 func Import(store Store) error {
 	statsURL := os.Getenv("REMOTE_STATS_URL")
@@ -107,12 +107,12 @@ func (s Series) MarshalJSON() ([]byte, error) {
 // of the top million domains over time.
 func Get(store Store) (map[string]Series, error) {
 	result := make(map[string]Series)
-	series, err := store.GetMTASTSStats(topDomainsSource)
+	series, err := store.GetStats(topDomainsSource)
 	if err != nil {
 		return result, err
 	}
 	result["top_million"] = series
-	series, err = store.GetMTASTSStats("local")
+	series, err = store.GetStats("local")
 	if err != nil {
 		return result, err
 	}

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -27,7 +27,7 @@ func (m *mockAgScanStore) PutLocalStats(date time.Time) (checker.AggregatedScan,
 	return a, nil
 }
 
-func (m *mockAgScanStore) GetMTASTSStats(source string) (Series, error) {
+func (m *mockAgScanStore) GetStats(source string) (Series, error) {
 	return Series{}, nil
 }
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -18,11 +18,16 @@ func (m *mockAgScanStore) PutAggregatedScan(agScan checker.AggregatedScan) error
 	return nil
 }
 
-func (m *mockAgScanStore) GetMTASTSStats(source string) (Series, error) {
-	return Series{}, nil
+func (m *mockAgScanStore) PutLocalStats(date time.Time) (checker.AggregatedScan, error) {
+	a := checker.AggregatedScan{
+		Source: "local",
+		Time:   date,
+	}
+	*m = append(*m, a)
+	return a, nil
 }
 
-func (m *mockAgScanStore) GetMTASTSLocalStats() (Series, error) {
+func (m *mockAgScanStore) GetMTASTSStats(source string) (Series, error) {
 	return Series{}, nil
 }
 
@@ -50,6 +55,7 @@ func TestImport(t *testing.T) {
 			enc.Encode(agScans[1])
 		}),
 	)
+	defer ts.Close()
 	os.Setenv("REMOTE_STATS_URL", ts.URL)
 	store := mockAgScanStore{}
 	err := Import(&store)
@@ -68,5 +74,15 @@ func TestImport(t *testing.T) {
 		if got.Source != topDomainsSource {
 			t.Errorf("Expected source for imported domains to be %s", topDomainsSource)
 		}
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	store := mockAgScanStore{}
+	Update(&store)
+	a := store[0]
+	// Confirm that date is trucated correctly
+	if a.Time.Hour() != 0 || a.Time.Minute() != 0 {
+		t.Errorf("Expected date to be truncated, got %v", a.Time)
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -9,17 +9,17 @@ import (
 	"time"
 
 	"github.com/EFForg/starttls-backend/checker"
-	"github.com/EFForg/starttls-backend/models"
 )
 
 func TestGetStats(t *testing.T) {
-	now := time.Now()
-	s := models.Scan{
-		Domain:    "example.com",
-		Data:      checker.NewSampleDomainResult("example.com"),
-		Timestamp: now,
-	}
-	api.Database.PutScan(s)
+	err := api.Database.PutAggregatedScan(checker.AggregatedScan{
+		Time:          time.Now(),
+		Source:        "local",
+		Attempted:     10,
+		WithMXs:       8,
+		MTASTSTesting: 3,
+		MTASTSEnforce: 2,
+	})
 
 	resp, err := http.Get(server.URL + "/api/stats")
 	if err != nil {
@@ -36,12 +36,7 @@ func TestGetStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	date := now.UTC().Truncate(24 * time.Hour).Format(time.RFC3339)
-	expectedX := fmt.Sprintf("\"x\": \"%v\"", date)
-	if !strings.Contains(string(body), expectedX) {
-		t.Errorf("Expected %s to contain %s", string(body), expectedX)
-	}
-	expectedY := fmt.Sprintf("\"y\": 100")
+	expectedY := fmt.Sprintf("\"y\": 62.5")
 	if !strings.Contains(string(body), expectedY) {
 		t.Errorf("Expected %s to contain %s", string(body), expectedY)
 	}


### PR DESCRIPTION
Rather than using a fancy query to pull stats over a rolling window from the DB, this PR adds a DB fn to query stats for a single 14-day window from the db and write them to an aggregated stats table. We can then access them from the aggregated stats table the same way we access aggregated stats from our scans of the top million domains.

Fixes #235