### PR TITLE
Read stats source from db

### DIFF
--- a/api/stats_test.go
+++ b/api/stats_test.go
@@ -21,6 +21,15 @@ func TestGetStats(t *testing.T) {
 		MTASTSEnforce: 2,
 	})
 
+	err = api.Database.PutAggregatedScan(checker.AggregatedScan{
+		Time:          time.Now(),
+		Source:        checker.TopDomainsSource,
+		Attempted:     10,
+		WithMXs:       8,
+		MTASTSTesting: 3,
+		MTASTSEnforce: 2,
+	})
+
 	resp, err := http.Get(server.URL + "/api/stats")
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +45,13 @@ func TestGetStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Local source returns a percent
 	expectedY := fmt.Sprintf("\"y\": 62.5")
+	if !strings.Contains(string(body), expectedY) {
+		t.Errorf("Expected %s to contain %s", string(body), expectedY)
+	}
+	// Top domains source returns a raw count
+	expectedY = fmt.Sprintf("\"y\": 5")
 	if !strings.Contains(string(body), expectedY) {
 		t.Errorf("Expected %s to contain %s", string(body), expectedY)
 	}

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -122,7 +122,7 @@ func (db *SQLDatabase) PutScan(scan models.Scan) error {
 func (db *SQLDatabase) GetStats(source string) (stats.Series, error) {
 	series := stats.Series{}
 	rows, err := db.conn.Query(
-		`SELECT time, with_mxs, mta_sts_testing, mta_sts_enforce
+		`SELECT time, source, with_mxs, mta_sts_testing, mta_sts_enforce
 		FROM aggregated_scans
 		WHERE source=$1
 		ORDER BY time`, source)
@@ -132,7 +132,7 @@ func (db *SQLDatabase) GetStats(source string) (stats.Series, error) {
 	defer rows.Close()
 	for rows.Next() {
 		var a checker.AggregatedScan
-		if err := rows.Scan(&a.Time, &a.WithMXs, &a.MTASTSTesting, &a.MTASTSEnforce); err != nil {
+		if err := rows.Scan(&a.Time, &a.Source, &a.WithMXs, &a.MTASTSTesting, &a.MTASTSEnforce); err != nil {
 			return series, err
 		}
 		series = append(series, a)


### PR DESCRIPTION
The source for stats (local vs the top domains list) was getting lost when reading from the db, which prevented the app from show a raw total for the MTA-STS adoption from the top million.