### PR TITLE
Add Sentry CLI to checker Dockerfile

### DIFF
--- a/checker/Dockerfile
+++ b/checker/Dockerfile
@@ -1,8 +1,12 @@
+FROM getsentry/sentry-cli AS sentry
+
 FROM golang:1.11-alpine
 
 WORKDIR /go/src/github.com/EFForg/starttls-backend/checker
 
 RUN apk add git
+
+COPY --from=sentry /bin/sentry-cli /bin
 
 COPY . .
 


### PR DESCRIPTION
Sentry builds their checker for Alpine in their Dockerfile. This PR copies the build out of their Dockerfile into ours.

The rest of the Sentry integration can go into the deploy repo for the top million domains scanner.

This is for #221 